### PR TITLE
Add support for right-click context menu

### DIFF
--- a/docs/how-to/context-menu.md
+++ b/docs/how-to/context-menu.md
@@ -1,0 +1,105 @@
+# Node Context Menus
+
+Panel-ReactFlow supports per-node context menus that appear on right-click.
+Define the menu content by overriding the `context_menu()` method on a `Node`
+subclass. The method returns any Panel component, which is rendered as a
+floating overlay at the click position.
+
+---
+
+## Define a context menu
+
+Override `context_menu()` on your `Node` subclass to return a Panel component.
+The menu is dismissed automatically when the user clicks elsewhere on the
+canvas.
+
+```python
+import panel as pn
+import panel_material_ui as pmui
+from panel_reactflow import Node, ReactFlow
+
+
+class TaskNode(Node):
+    def context_menu(self):
+        return pn.Column(
+            pmui.Button(name="Run", variant="text", size="small"),
+            pmui.Button(name="Delete", variant="text", color="error", size="small"),
+        )
+
+
+flow = ReactFlow(nodes=[
+    TaskNode(id="t1", position={"x": 0, "y": 0}, label="My Task", data={}),
+])
+```
+
+---
+
+## Access node state in the menu
+
+The `context_menu()` method runs on the node instance, so you have access to
+all its parameters and the parent flow via `self.flow`.
+
+```python
+class PipelineNode(Node):
+    status = param.Selector(
+        default="idle", objects=["idle", "running", "done"], precedence=0
+    )
+
+    def context_menu(self):
+        def set_status(status):
+            self.flow.patch_node_data(self.id, {"status": status})
+            # Close the menu after action
+            self.flow._handle_msg({"type": "close_context_menu"})
+
+        return pn.Column(
+            pn.pane.Markdown(f"**{self.label}** ({self.status})"),
+            pmui.Button(
+                name="Start", variant="text", size="small",
+                on_click=lambda e: set_status("running"),
+            ),
+            pmui.Button(
+                name="Delete", variant="text", color="error", size="small",
+                on_click=lambda e: self.flow.remove_node(self.id),
+            ),
+        )
+```
+
+---
+
+## Close the menu programmatically
+
+The context menu closes when the user clicks anywhere on the canvas pane.
+To close it from a button callback (e.g. after performing an action), send
+the close message:
+
+```python
+self.flow._handle_msg({"type": "close_context_menu"})
+```
+
+---
+
+## Listen for context menu events
+
+You can also react to the right-click event without rendering a menu by
+subscribing to the `"node_context_menu"` event:
+
+```python
+def on_context(payload, flow):
+    print(f"Right-clicked node {payload['node_id']} at {payload['position']}")
+
+flow.on("node_context_menu", on_context)
+```
+
+The payload includes `node_id` and `position` (with `x` and `y` screen
+coordinates).
+
+---
+
+## Tips
+
+- Return `None` from `context_menu()` to disable the menu for specific nodes
+  (this is the default behavior).
+- Only `Node` subclass instances support context menus. Dict-based nodes do
+  not trigger a context menu on right-click.
+- The menu overlay uses the `.rf-context-menu` CSS class for styling. Override
+  it in a custom stylesheet to change appearance.

--- a/docs/how-to/react-to-events.md
+++ b/docs/how-to/react-to-events.md
@@ -23,6 +23,7 @@ the `ReactFlow` instance as a second argument.  You can also listen for
 | `node_deleted`       | A node is removed. | `node_id` |
 | `node_moved`         | A node is dragged to a new position. | `node_id`, `position` |
 | `node_clicked`       | A node is clicked (single click). | `node_id` |
+| `node_context_menu`  | A node is right-clicked. | `node_id`, `position` |
 | `node_data_changed`  | Node data is patched (via API, editor patch, or parameter-driven sync). | `node_id`, `patch` |
 | `edge_added`         | An edge is created (UI connect or API). | `edge` |
 | `edge_deleted`       | An edge is removed. | `edge_id` |

--- a/examples/context_menu.py
+++ b/examples/context_menu.py
@@ -1,0 +1,82 @@
+"""Context menu example using Node subclasses.
+
+Demonstrates:
+- Per-node context menus via ``Node.context_menu()``
+- Dynamic menu content based on node state
+- Closing the menu on action (via ``flow.patch_node_data``)
+"""
+
+import panel as pn
+import panel_material_ui as pmui
+import param
+
+from panel_reactflow import Node, ReactFlow
+
+pn.extension()
+
+
+class TaskNode(Node):
+    status = param.Selector(
+        default="idle", objects=["idle", "running", "done", "failed"], precedence=0
+    )
+
+    def __init__(self, **params):
+        params.setdefault("type", "panel")
+        super().__init__(**params)
+
+    def __panel__(self):
+        return pn.pane.Markdown(
+            f"**{self.label}**\n\nStatus: `{self.status}`",
+            sizing_mode="stretch_width",
+        )
+
+    def context_menu(self):
+        def set_status(status):
+            self.flow.patch_node_data(self.id, {"status": status})
+            self.flow._handle_msg({"type": "close_context_menu"})
+
+        run_btn = pmui.Button(
+            name="Run", variant="text", size="small",
+            on_click=lambda e: set_status("running"),
+        )
+        done_btn = pmui.Button(
+            name="Mark Done", variant="text", size="small",
+            on_click=lambda e: set_status("done"),
+        )
+        reset_btn = pmui.Button(
+            name="Reset", variant="text", size="small",
+            on_click=lambda e: set_status("idle"),
+        )
+        delete_btn = pmui.Button(
+            name="Delete", variant="text", color="error", size="small",
+            on_click=lambda e: self.flow.remove_node(self.id),
+        )
+
+        return pn.Column(
+            pn.pane.Markdown(f"**{self.label}**", margin=(4, 8)),
+            run_btn, done_btn, reset_btn, delete_btn,
+            sizing_mode="stretch_width",
+            margin=0,
+        )
+
+
+nodes = [
+    TaskNode(id="extract", label="Extract", position={"x": 0, "y": 0}),
+    TaskNode(id="transform", label="Transform", position={"x": 300, "y": 80}),
+    TaskNode(id="load", label="Load", position={"x": 600, "y": 0}, status="done"),
+]
+
+flow = ReactFlow(
+    nodes=nodes,
+    edges=[
+        {"id": "e1", "source": "extract", "target": "transform"},
+        {"id": "e2", "source": "transform", "target": "load"},
+    ],
+    sizing_mode="stretch_both",
+)
+
+pn.Column(
+    pn.pane.Markdown("## Context Menu Demo\nRight-click any node to see its context menu."),
+    flow,
+    sizing_mode="stretch_both",
+).servable()

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "panel-reactflow"
-channels = ["conda-forge", "pyviz/label/dev"]
+channels = ["pyviz/label/dev", "conda-forge"]
 platforms = ["osx-arm64", "osx-64", "linux-64", "win-64"]
 
 [tasks]

--- a/src/panel_reactflow/base.py
+++ b/src/panel_reactflow/base.py
@@ -18,7 +18,7 @@ import param
 from bokeh.embed.bundle import extension_dirs
 from bokeh.plotting import figure
 from panel.config import config
-from panel.custom import Children, ReactComponent
+from panel.custom import Child, Children, ReactComponent
 from panel.io.resources import EXTENSION_CDN
 from panel.io.state import state
 from panel.util import base_version, classproperty
@@ -681,6 +681,14 @@ class Node(param.Parameterized):
         """Optional per-node editor factory.
 
         Return ``None`` to fall back to type/default editors.
+        """
+        return None
+
+    def context_menu(self) -> Any | None:
+        """Return a Panel component to render as a context menu on right-click.
+
+        Override this method to provide a custom context menu for this node.
+        Return ``None`` to disable the context menu for this node.
         """
         return None
 
@@ -1447,6 +1455,9 @@ class ReactFlow(ReactComponent):
     _node_editor_views = Children(default=[], doc="Node editor views (one per node, same order).")
     _edge_editors = param.Dict(default={}, doc="Per-edge editors.", precedence=-1)
     _edge_editor_views = Children(default=[], doc="Edge editor views (one per edge, same order).")
+    _selected_editor = Child(doc="Active editor for the selected node/edge in side mode.")
+    _context_menu = Child(doc="Context menu component rendered on node right-click.")
+    _context_menu_position = param.Dict(default=None, allow_None=True, doc="Screen position for the context menu overlay.")
     _views = Children(default=[], doc="Panel viewables rendered inside nodes via view_idx.")
     _node_update_count = param.Integer(default=0, doc="Monotonic counter for normalized node updates.")
 
@@ -1487,16 +1498,21 @@ class ReactFlow(ReactComponent):
         self.param.watch(self._normalize_specs, ["node_types", "edge_types"])
         self.param.watch(
             self._update_node_editors,
-            ["nodes", "editor_mode", "selection", "node_editors", "default_node_editor"],
+            ["nodes", "editor_mode", "node_editors", "default_node_editor"],
         )
         self.param.watch(
             self._update_edge_editors,
-            ["edges", "selection", "edge_editors", "default_edge_editor"],
+            ["edges", "edge_editors", "default_edge_editor"],
+        )
+        self.param.watch(
+            self._update_selected_editor,
+            ["selection", "editor_mode", "nodes", "edges"],
         )
         self.param.watch(self._update_views, ["nodes"])
         self._sync_instance_flow_refs()
         self._update_node_editors()
         self._update_edge_editors()
+        self._update_selected_editor()
         self._update_instance_data_param_watchers()
 
     @classmethod
@@ -1963,6 +1979,24 @@ class ReactFlow(ReactComponent):
         self._edge_editors = editors
         self.param.trigger("_edge_editor_views")
 
+    def _update_selected_editor(self, *events: tuple[param.parameterized.Event]) -> None:
+        if self.editor_mode != "side":
+            if self._selected_editor is not None:
+                self._selected_editor = None
+            return
+        selected_nodes = self.selection.get("nodes", [])
+        selected_edges = self.selection.get("edges", [])
+        editor = None
+        if selected_nodes:
+            editor = self._node_editors.get(selected_nodes[0])
+        elif selected_edges:
+            editor = self._edge_editors.get(selected_edges[0])
+        if editor is not None:
+            view = self._resolve_editor_view(editor)
+        else:
+            view = None
+        self._selected_editor = view
+
     @staticmethod
     def _resolve_editor_view(editor: Any) -> Any:
         """Return a Panel viewable from an editor (class or plain object)."""
@@ -1974,13 +2008,10 @@ class ReactFlow(ReactComponent):
 
     def _get_children(self, data_model, doc, root, parent, comm) -> tuple[dict[str, list[UIElement] | UIElement | None], list[UIElement]]:
         views = []
-        node_editors = []
         for node in self.nodes:
             view = self._node_view(node)
             if view is not None:
                 views.append(self._resolve_editor_view(view))
-            node_editors.append(self._resolve_editor_view(self._node_editors.get(self._node_id(node))))
-        edge_editors = [self._resolve_editor_view(self._edge_editors.get(self._edge_id(edge))) for edge in self.edges]
 
         children: dict[str, list[UIElement] | UIElement | None] = {}
         old_models: list[UIElement] = []
@@ -1988,20 +2019,32 @@ class ReactFlow(ReactComponent):
         self._patch_views(view_models)
         children["_views"] = views
         old_models += view_models
-        editor_models, editor_old = self._get_child_model(node_editors, doc, root, parent, comm)
-        children["_node_editor_views"] = editor_models
-        old_models += editor_old
-        edge_models, edge_old = self._get_child_model(edge_editors, doc, root, parent, comm)
-        children["_edge_editor_views"] = edge_models
-        old_models += edge_old
-        for name in ("top_panel", "bottom_panel", "left_panel", "right_panel"):
-            panels = list(getattr(self, name, []) or [])
-            if panels:
-                panel_models, panel_old = self._get_child_model(panels, doc, root, parent, comm)
-                children[name] = panel_models
-                old_models += panel_old
+
+        if self.editor_mode == "side":
+            children["_node_editor_views"] = []
+            children["_edge_editor_views"] = []
+        else:
+            node_editors = [self._resolve_editor_view(self._node_editors.get(self._node_id(node))) for node in self.nodes]
+            editor_models, editor_old = self._get_child_model(node_editors, doc, root, parent, comm)
+            children["_node_editor_views"] = editor_models
+            old_models += editor_old
+            children["_edge_editor_views"] = []
+
+        for name in ("top_panel", "bottom_panel", "left_panel", "right_panel", "_context_menu", "_selected_editor"):
+            panels = getattr(self, name, None)
+            if panels is None:
+                children[name] = None
+            elif isinstance(panels, list):
+                if panels:
+                    panel_models, panel_old = self._get_child_model(panels, doc, root, parent, comm)
+                    children[name] = panel_models
+                    old_models += panel_old
+                else:
+                    children[name] = []
             else:
-                children[name] = []
+                panel_models, panel_old = self._get_child_model([panels], doc, root, parent, comm)
+                children[name] = panel_models[0] if panel_models else None
+                old_models += panel_old
         return children, old_models
 
     def _patch_views(self, view_models: list[UIElement]) -> None:
@@ -2247,6 +2290,23 @@ class ReactFlow(ReactComponent):
                 if node_id is None:
                     return
                 self._emit("node_clicked", msg)
+            case "node_context_menu":
+                node_id = msg.get("node_id")
+                position = msg.get("position")
+                if node_id is None:
+                    return
+                node = next((n for n in self.nodes if self._node_id(n) == node_id), None)
+                if node is None or not isinstance(node, Node):
+                    return
+                menu = node.context_menu()
+                if menu is None:
+                    return
+                self._context_menu = menu
+                self._context_menu_position = position
+                self._emit("node_context_menu", msg)
+            case "close_context_menu":
+                self._context_menu = None
+                self._context_menu_position = None
             case _:
                 return
 

--- a/src/panel_reactflow/base.py
+++ b/src/panel_reactflow/base.py
@@ -1995,16 +1995,12 @@ class ReactFlow(ReactComponent):
         self.param.trigger("_edge_editor_views")
 
     def _update_selected_editor(self, *events: tuple[param.parameterized.Event]) -> None:
-        if self.editor_mode != "side":
-            if self._selected_editor is not None:
-                self._selected_editor = None
-            return
         selected_nodes = self.selection.get("nodes", [])
         selected_edges = self.selection.get("edges", [])
         editor = None
-        if selected_nodes:
+        if selected_nodes and self.editor_mode == "side":
             editor = self._node_editors.get(selected_nodes[0])
-        elif selected_edges:
+        elif selected_edges and not selected_nodes:
             editor = self._edge_editors.get(selected_edges[0])
         if editor is not None:
             view = self._resolve_editor_view(editor)
@@ -2282,6 +2278,7 @@ class ReactFlow(ReactComponent):
                 for edge in self.edges:
                     self._edge_set_selected(edge, self._edge_id(edge) in edge_ids)
                 self.selection = {"nodes": list(node_ids), "edges": list(edge_ids)}
+                self._update_selected_editor()
                 self._emit("selection_changed", msg)
             case "edge_added":
                 edge = msg.get("edge")

--- a/src/panel_reactflow/dist/css/reactflow.css
+++ b/src/panel_reactflow/dist/css/reactflow.css
@@ -79,3 +79,12 @@
 .rf-node-toolbar-icon--closed {
     transform: none;
 }
+
+.rf-context-menu {
+    background: var(--xy-node-background-color, var(--panel-background-color));
+    border: 1px solid var(--panel-border-color);
+    border-radius: 6px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    padding: 4px;
+    min-width: 120px;
+}

--- a/src/panel_reactflow/models/reactflow.jsx
+++ b/src/panel_reactflow/models/reactflow.jsx
@@ -857,20 +857,34 @@ export function render({ model, view }) {
     return mapping;
   }, [editorMode, pyNodeTypes]);
 
-  const closeContextMenu = useCallback(() => {
-    if (contextMenuPosition) {
-      model.send_msg({ type: "close_context_menu" });
-    }
-  }, [model, contextMenuPosition]);
-
-  const handlePaneClick = useCallback(
-    (event) => {
-      closeContextMenu();
-    },
-    [closeContextMenu],
-  );
-
+  const contextMenuRef = useRef(null);
   const containerRef = useRef(null);
+
+  useEffect(() => {
+    if (!contextMenuPosition) return;
+    const handleClick = (event) => {
+      const el = contextMenuRef.current;
+      if (el) {
+        const rect = el.getBoundingClientRect();
+        if (
+          event.clientX >= rect.left &&
+          event.clientX <= rect.right &&
+          event.clientY >= rect.top &&
+          event.clientY <= rect.bottom
+        ) {
+          return;
+        }
+      }
+      model.send_msg({ type: "close_context_menu" });
+    };
+    const id = requestAnimationFrame(() => {
+      document.addEventListener("mousedown", handleClick, true);
+    });
+    return () => {
+      cancelAnimationFrame(id);
+      document.removeEventListener("mousedown", handleClick, true);
+    };
+  }, [contextMenuPosition, model]);
 
   const hydratedEdgeTypes = useMemo(() => ({
     bezier: BezierEdge,
@@ -908,7 +922,6 @@ export function render({ model, view }) {
           syncMode={syncMode}
           debounceMs={debounceMs}
           viewport={viewport}
-          onPaneClick={handlePaneClick}
         />
         <Panel key="top-panel" position="top-center">
           {topPanels}
@@ -926,6 +939,7 @@ export function render({ model, view }) {
       </ReactFlowProvider>
       {contextMenu && contextMenuPosition ? (
         <div
+          ref={contextMenuRef}
           className="rf-context-menu"
           style={{
             position: "absolute",

--- a/src/panel_reactflow/models/reactflow.jsx
+++ b/src/panel_reactflow/models/reactflow.jsx
@@ -252,7 +252,6 @@ function FlowInner({
   defaultEdgeOptions,
   nodeTypes,
   nodeEditors,
-  edgeEditors,
   colorMode,
   editable,
   enableConnect,
@@ -269,7 +268,7 @@ function FlowInner({
   const edgesRef = useRef(edges);
   const hydrationFrameRef = useRef(null);
   const edgeHydrationFrameRef = useRef(null);
-  const lastHydrated = useRef({ nodeRevision: null, nodesSig: null, edgesSig: null, edgeEditorsSig: null });
+  const lastHydrated = useRef({ nodeRevision: null, nodesSig: null, edgesSig: null });
   const lastViewportSig = useRef(null);
   const { setViewport: setRfViewport } = useReactFlow();
 
@@ -368,10 +367,8 @@ function FlowInner({
 
   useEffect(() => {
     const edgesSig = signature(hydratedEdges);
-    const editorsSig = signature((edgeEditors || []).map((editor) => editor?.props?.id ?? null));
-    if (edgesSig !== lastHydrated.current.edgesSig || editorsSig !== lastHydrated.current.edgeEditorsSig) {
+    if (edgesSig !== lastHydrated.current.edgesSig) {
       lastHydrated.current.edgesSig = edgesSig;
-      lastHydrated.current.edgeEditorsSig = editorsSig;
       if (edgeHydrationFrameRef.current !== null) {
         cancelAnimationFrame(edgeHydrationFrameRef.current);
       }
@@ -380,7 +377,7 @@ function FlowInner({
         edgeHydrationFrameRef.current = null;
       });
     }
-  }, [hydratedEdges, setEdges, edgeEditors]);
+  }, [hydratedEdges, setEdges]);
 
   useEffect(() => {
     if (viewport) {
@@ -480,6 +477,18 @@ function FlowInner({
     [schedulePatch],
   );
 
+  const onNodeContextMenu = useCallback(
+    (event, node) => {
+      event.preventDefault();
+      sendPatch({
+        type: "node_context_menu",
+        node_id: node.id,
+        position: { x: event.clientX, y: event.clientY },
+      });
+    },
+    [sendPatch],
+  );
+
   const onMoveEnd = useCallback(
     (_event, nextViewport) => {
       if (!areEqual(nextViewport, viewport)) {
@@ -504,6 +513,7 @@ function FlowInner({
       onConnect={onConnect}
       onMoveEnd={onMoveEnd}
       onNodeDoubleClick={onNodeDoubleClick}
+      onNodeContextMenu={onNodeContextMenu}
       onPaneClick={onPaneClick}
       nodesDraggable={editable}
       nodesConnectable={editable && enableConnect}
@@ -538,9 +548,11 @@ export function render({ model, view }) {
   const [enableMultiselect] = model.useState("enable_multiselect");
   const [showMinimap] = model.useState("show_minimap");
   const [viewport, setViewport] = model.useState("viewport");
+  const [contextMenuPosition] = model.useState("_context_menu_position");
+  const contextMenu = model.get_child("_context_menu");
+  const selectedEditor = model.get_child("_selected_editor");
   const views = model.get_child("_views");
   const nodeEditors = model.get_child("_node_editor_views");
-  const edgeEditors = model.get_child("_edge_editor_views");
   const topPanels = model.get_child("top_panel");
   const bottomPanels = model.get_child("bottom_panel");
   const leftPanels = model.get_child("left_panel");
@@ -548,17 +560,6 @@ export function render({ model, view }) {
 
   const allNodeTypes = useMemo(() => ({ ...BUILTIN_NODE_TYPES, ...(pyNodeTypes || {}) }), [pyNodeTypes]);
 
-  const nodeEditorMap = {};
-  const nodeHasEditorMap = {};
-  pyNodes.forEach((node, idx) => {
-    if (node && node.id !== undefined) {
-      nodeEditorMap[node.id] = nodeEditors[idx];
-      const data = node.data || {};
-      const typeSpec = allNodeTypes[node.type] || {};
-      const realKeys = Object.keys(data).filter((k) => k !== "view_idx");
-      nodeHasEditorMap[node.id] = realKeys.length > 0 || !!typeSpec.schema;
-    }
-  });
 
   useEffect(() => {
     const clearReadyCheckTimeouts = () => {
@@ -624,15 +625,6 @@ export function render({ model, view }) {
     };
   }, [model, view]);
 
-  const edgeEditorMap = {};
-  const edgeHasEditorMap = {};
-  (pyEdges || []).forEach((edge, idx) => {
-    if (edge && edge.id !== undefined) {
-      edgeEditorMap[edge.id] = edgeEditors[idx];
-      const data = edge.data || {};
-      edgeHasEditorMap[edge.id] = Object.keys(data).length > 0;
-    }
-  });
 
   const hydratedNodes = useMemo(() => {
     return (pyNodes || []).map((node, idx) => {
@@ -680,8 +672,25 @@ export function render({ model, view }) {
     return mapping;
   }, [editorMode, pyNodeTypes]);
 
+  const closeContextMenu = useCallback(() => {
+    if (contextMenuPosition) {
+      model.send_msg({ type: "close_context_menu" });
+    }
+  }, [model, contextMenuPosition]);
+
+  const handlePaneClick = useCallback(
+    (event) => {
+      closeContextMenu();
+    },
+    [closeContextMenu],
+  );
+
+  const containerRef = useRef(null);
+
+  console.log(contextMenu, contextMenuPosition)
+
   return (
-    <div style={{ width: "100%", height: "100%" }}>
+    <div ref={containerRef} style={{ width: "100%", height: "100%", position: "relative" }}>
       <ReactFlowProvider>
         <FlowInner
           model={model}
@@ -697,7 +706,6 @@ export function render({ model, view }) {
           colorMode={colorMode}
           nodeTypes={hydratedNodeTypes}
           nodeEditors={nodeEditors}
-          edgeEditors={edgeEditors}
           editable={editable}
           enableConnect={enableConnect}
           enableDelete={enableDelete}
@@ -706,6 +714,7 @@ export function render({ model, view }) {
           syncMode={syncMode}
           debounceMs={debounceMs}
           viewport={viewport}
+          onPaneClick={handlePaneClick}
         />
         <Panel key="top-panel" position="top-center">
           {topPanels}
@@ -718,10 +727,22 @@ export function render({ model, view }) {
         </Panel>
         <Panel key="right-panel" position="center-right">
           {rightPanels}
-          {selection.nodes.length && editorMode === "side" && nodeHasEditorMap[selection.nodes[0]] ? nodeEditorMap[selection.nodes[0]] : null}
-          {selection.edges.length && !selection.nodes.length && edgeHasEditorMap[selection.edges[0]] ? edgeEditorMap[selection.edges[0]] : null}
+          {editorMode === "side" ? selectedEditor : null}
         </Panel>
       </ReactFlowProvider>
+      {contextMenu && contextMenuPosition ? (
+        <div
+          className="rf-context-menu"
+          style={{
+            position: "absolute",
+            top: contextMenuPosition.y - (containerRef.current?.getBoundingClientRect().top ?? 0),
+            left: contextMenuPosition.x - (containerRef.current?.getBoundingClientRect().left ?? 0),
+            zIndex: 1000,
+          }}
+        >
+          {contextMenu}
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/src/panel_reactflow/models/reactflow.jsx
+++ b/src/panel_reactflow/models/reactflow.jsx
@@ -921,7 +921,7 @@ export function render({ model, view }) {
         </Panel>
         <Panel key="right-panel" position="center-right">
           {rightPanels}
-          {editorMode === "side" ? selectedEditor : null}
+          {selectedEditor}
         </Panel>
       </ReactFlowProvider>
       {contextMenu && contextMenuPosition ? (

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -73,6 +73,8 @@ def test_reactflow_add_node_dynamically_creates_views(document, comm):
         "bottom_panel",
         "left_panel",
         "right_panel",
+        "_context_menu",
+        "_selected_editor",
     ]
 
     flow.add_node({"id": "n1", "position": {"x": 0, "y": 0}, "label": "Viewer Node", "data": {}, "view": Markdown("foo")})
@@ -110,10 +112,12 @@ def test_bokeh_children_initialize_for_object_views_and_editors(document, comm) 
         "bottom_panel",
         "left_panel",
         "right_panel",
+        "_context_menu",
+        "_selected_editor",
     ]
     assert len(model.data._views) == 1
     assert len(model.data._node_editor_views) == 2
-    assert len(model.data._edge_editor_views) == 1
+    assert len(model.data._edge_editor_views) == 0
 
     by_id = {node["id"]: node for node in model.data.nodes}
     assert by_id["n1"]["data"]["view_idx"] == 0

--- a/tests/ui/test_context_menu.py
+++ b/tests/ui/test_context_menu.py
@@ -68,7 +68,9 @@ def test_context_menu_closes_on_pane_click(page):
     menu = page.locator(".rf-context-menu")
     expect(menu).to_be_visible()
 
-    page.locator(".react-flow__pane").click(force=True)
+    pane = page.locator(".react-flow__pane")
+    box = pane.bounding_box()
+    page.mouse.click(box["x"] + box["width"] - 50, box["y"] + box["height"] - 50)
 
     expect(menu).not_to_be_visible()
     wait_until(lambda: flow._context_menu is None, timeout=8000)

--- a/tests/ui/test_context_menu.py
+++ b/tests/ui/test_context_menu.py
@@ -1,0 +1,150 @@
+"""UI tests for node context menu feature."""
+
+import panel as pn
+import param
+import pytest
+from panel.tests.util import serve_component, wait_until
+
+from panel_reactflow import Node, NodeSpec, ReactFlow
+
+pytest.importorskip("playwright")
+
+from playwright.sync_api import expect
+
+pytestmark = pytest.mark.ui
+
+
+class MenuNode(Node):
+    status = param.Selector(default="idle", objects=["idle", "running", "done"], precedence=0)
+
+    def context_menu(self):
+        return pn.Column(
+            pn.pane.Markdown(f"**Menu: {self.label}**"),
+            pn.widgets.Button(label="Run"),
+            pn.widgets.Button(label="Delete"),
+        )
+
+
+class NoMenuNode(Node):
+    pass
+
+
+def _node_locator(page, label):
+    return page.locator(".react-flow__node").filter(has_text=label)
+
+
+def test_context_menu_appears_on_right_click(page):
+    flow = ReactFlow(
+        nodes=[MenuNode(id="n1", position={"x": 0, "y": 0}, label="Task A", data={})],
+        width=900,
+        height=600,
+    )
+    serve_component(page, flow)
+
+    node = _node_locator(page, "Task A")
+    expect(node).to_be_visible()
+
+    node.click(button="right")
+
+    menu = page.locator(".rf-context-menu")
+    expect(menu).to_be_visible()
+    expect(menu.locator("text=Menu: Task A")).to_be_visible()
+
+    wait_until(lambda: flow._context_menu is not None, timeout=8000)
+    wait_until(lambda: flow._context_menu_position is not None, timeout=8000)
+
+
+def test_context_menu_closes_on_pane_click(page):
+    flow = ReactFlow(
+        nodes=[MenuNode(id="n1", position={"x": 0, "y": 0}, label="Task A", data={})],
+        width=900,
+        height=600,
+    )
+    serve_component(page, flow)
+
+    node = _node_locator(page, "Task A")
+    node.click(button="right")
+
+    menu = page.locator(".rf-context-menu")
+    expect(menu).to_be_visible()
+
+    page.locator(".react-flow__pane").click(force=True)
+
+    expect(menu).not_to_be_visible()
+    wait_until(lambda: flow._context_menu is None, timeout=8000)
+
+
+def test_context_menu_not_shown_for_node_without_menu(page):
+    flow = ReactFlow(
+        nodes=[NoMenuNode(id="n1", position={"x": 0, "y": 0}, label="Plain", data={})],
+        width=900,
+        height=600,
+    )
+    serve_component(page, flow)
+
+    node = _node_locator(page, "Plain")
+    expect(node).to_be_visible()
+
+    node.click(button="right")
+
+    page.wait_for_timeout(500)
+    menu = page.locator(".rf-context-menu")
+    expect(menu).not_to_be_visible()
+    assert flow._context_menu is None
+
+
+def test_context_menu_not_shown_for_dict_node(page):
+    flow = ReactFlow(
+        nodes=[NodeSpec(id="n1", position={"x": 0, "y": 0}, label="Dict Node", data={}).to_dict()],
+        width=900,
+        height=600,
+    )
+    serve_component(page, flow)
+
+    node = _node_locator(page, "Dict Node")
+    expect(node).to_be_visible()
+
+    node.click(button="right")
+
+    page.wait_for_timeout(500)
+    menu = page.locator(".rf-context-menu")
+    expect(menu).not_to_be_visible()
+    assert flow._context_menu is None
+
+
+def test_context_menu_emits_event(page):
+    events = []
+
+    flow = ReactFlow(
+        nodes=[MenuNode(id="n1", position={"x": 0, "y": 0}, label="Task A", data={})],
+        width=900,
+        height=600,
+    )
+    flow.on("node_context_menu", lambda payload: events.append(payload))
+    serve_component(page, flow)
+
+    node = _node_locator(page, "Task A")
+    node.click(button="right")
+
+    wait_until(lambda: len(events) == 1, timeout=8000)
+    assert events[0]["node_id"] == "n1"
+    assert "position" in events[0]
+
+
+def test_context_menu_updates_on_different_node(page):
+    flow = ReactFlow(
+        nodes=[
+            MenuNode(id="n1", position={"x": 0, "y": 0}, label="First"),
+            MenuNode(id="n2", position={"x": 300, "y": 0}, label="Second"),
+        ],
+        width=900,
+        height=600,
+    )
+    serve_component(page, flow)
+
+    _node_locator(page, "First").click(button="right")
+    menu = page.locator(".rf-context-menu")
+    expect(menu.locator("text=Menu: First")).to_be_visible()
+
+    _node_locator(page, "Second").click(button="right")
+    expect(menu.locator("text=Menu: Second")).to_be_visible()


### PR DESCRIPTION
 ## Description

Adds two features to panel-reactflow:

1. Node context menus

Adds support for per-node right-click context menus via a new Node.context_menu() method. Users override this method on their Node subclass to return any Panel component, which is rendered as a floating overlay at the click position.

```
from panel_reactflow import Node, ReactFlow
import panel as pn

class TaskNode(Node):
      def context_menu(self):
            return pn.Column(
                pn.widgets.Button(label="Run"),
                pn.widgets.Button(label="Delete"),
            )

flow = ReactFlow(nodes=[TaskNode(id="t1", position={"x": 0, "y": 0})])
```

- Menu appears on right-click, dismissed on pane click
- Only works for Node subclass instances (dict nodes are ignored)
- Returning None disables the menu (default behavior)
- Emits a "node_context_menu" event with node_id and position

2. Editor rendering optimization

Previously, all node and edge editor views were serialized and sent to the frontend regardless of whether they were visible. This is wasteful, especially in "side" mode where only one editor is shown at a time.

Now:
- Side mode: Only the selected node/edge editor is sent via a new _selected_editor Child parameter (instead of N editors)
- Node/toolbar mode: Node editors still sent per-node (all are needed), but edge editors are no longer sent (they were never rendered in these modes)
- Removed dead JS code (edgeEditorMap, nodeEditorMap, edgeEditors prop on FlowInner)

## AI Disclosure

- Tool & Model: Claude Code + Opus 4.6
- Usage: Implementation of both features including Python, JSX, CSS, tests, documentation, and examples.
- [x] I have tested all AI-generated content in my PR.
- [x] I take responsibility for all AI-generated content in my PR.

## Checklist

- [x] Tests added and are passing
- [x] Added documentation