### PR TITLE
Sync base Node/Edge params (label/style/type/...) to the frontend

### DIFF
--- a/docs/how-to/define-nodes-edges.md
+++ b/docs/how-to/define-nodes-edges.md
@@ -358,25 +358,44 @@ Without `sourceHandle` and `targetHandle`, edges connect to the default (first) 
 
 ---
 
-## Update data vs. label
+## Update data vs. presentation
 
-`data` and `label` live in different places and are updated differently:
-
-- **Data** — use `patch_node_data()` or `patch_edge_data()`.  This sends
-  an incremental patch to the frontend without replacing the full list.
-- **Label** — replace the node/edge in `flow.nodes` or `flow.edges`.
+A node or edge has an arbitrary `data` dictionary plus a set of top-level React
+Flow fields (`label`, `style`, `type`, `className`, `position`, ...).  Each has
+its own patch method, and both send an incremental update to the frontend
+instead of replacing the full list:
 
 ```python
 # Patch a data field
 flow.patch_node_data("n1", {"status": "running"})
 flow.patch_edge_data("e1", {"weight": 0.75})
 
-# Update a label
-flow.nodes = [
-    {**node, "label": "Start (running)"} if node["id"] == "n1" else node
-    for node in flow.nodes
-]
+# Patch a top-level field
+flow.patch_node_props("n1", {"label": "Start (running)", "className": "busy"})
+flow.patch_edge_props("e1", {"style": {"stroke": "#ef4444", "strokeWidth": 4}, "type": "step"})
 ```
+
+Passing `None` to `patch_node_props()`/`patch_edge_props()` clears the field so
+the element falls back to the CSS/theme default:
+
+```python
+flow.patch_edge_props("e1", {"style": None})
+```
+
+If you use `Node`/`Edge` subclasses, you rarely need either method: assigning to
+a parameter patches the browser in place.  Parameters you declare on the
+subclass are synced into `data`, the presentational base parameters are synced
+as top-level fields.
+
+```python
+node.label = "Start (running)"                  # top-level label
+edge.style = {"stroke": "#ef4444"}              # top-level style
+edge.weight = 0.75                              # subclass param, goes into data
+```
+
+`position` and `selected` are the exception: the browser owns them while the
+user drags or selects, so assignment does not push them.  Use
+`patch_node_props()` to move or select a node from Python.
 
 ---
 

--- a/src/panel_reactflow/base.py
+++ b/src/panel_reactflow/base.py
@@ -8,10 +8,11 @@ import json
 import logging
 import os
 from collections.abc import Callable
+from contextlib import contextmanager
 from dataclasses import dataclass
 from functools import partial
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, ClassVar, Literal
+from typing import TYPE_CHECKING, Any, Literal
 from uuid import uuid4
 
 import panel as pn
@@ -630,7 +631,47 @@ class Node(param.Parameterized):
     - ``__panel__`` to render node content.
     - ``editor`` to provide a node-specific editor.
     - ``on_event`` (wildcard) and event-specific ``on_*`` hooks.
+
+    Assigning to a parameter after the node is part of a graph updates the
+    browser in place, without re-serializing the whole ``ReactFlow.nodes``
+    list. Parameters declared on a subclass are synced into the node's
+    ``data``; the presentational base parameters listed in ``_synced_props``
+    are synced as top-level React Flow fields.
     """
+
+    # Fields ``to_dict`` serializes outside ``data``, i.e. the ones
+    # ``ReactFlow.patch_node_props`` may update in place.
+    _props = (
+        "position",
+        "type",
+        "label",
+        "selected",
+        "draggable",
+        "connectable",
+        "deletable",
+        "style",
+        "className",
+    )
+
+    # Subset of ``_props`` pushed to the browser on assignment. ``position``
+    # and ``selected`` are driven by the frontend while the user drags or
+    # selects, so echoing them back would fight the pointer mid-interaction;
+    # use ``ReactFlow.patch_node_props`` to set them explicitly.
+    _synced_props = (
+        "type",
+        "label",
+        "draggable",
+        "connectable",
+        "deletable",
+        "style",
+        "className",
+    )
+
+    # ``data`` keys ``ReactFlow.patch_node_data`` mirrors onto a top-level
+    # property. The node components render the label out of ``data._label``, so
+    # a data patch that carries a label has to update the parameter too or the
+    # next full serialization reverts it.
+    _mirrored_data_keys = {"label": "label", "_label": "label"}
 
     id = param.String(default="", doc="Unique node identifier.")
     position = param.Dict(default={"x": 0.0, "y": 0.0}, doc="Node position.")
@@ -644,12 +685,6 @@ class Node(param.Parameterized):
     style = param.Dict(default=None, allow_None=True, doc="Optional node style.")
     className = param.String(default=None, allow_None=True, doc="Optional CSS class.")
     flow = param.Parameter(default=None, allow_None=True, precedence=-1, doc="Parent ReactFlow instance.")
-
-    #: Base params that map to top-level React Flow node fields rather than
-    #: arbitrary ``data`` payload keys. Assigning one of these on a live
-    #: ``Node`` instance is watched and synced to the frontend, just like
-    #: subclass-defined data params (see ``_data_param_names``).
-    _TOP_LEVEL_SYNC_PARAMS: ClassVar[tuple[str, ...]] = ("label", "style", "className")
 
     @classmethod
     def _data_param_names(cls) -> list[str]:
@@ -720,6 +755,9 @@ class Node(param.Parameterized):
 
     def on_data_change(self, payload: dict[str, Any], flow: "ReactFlow") -> None:
         """Hook called when this node's data changes."""
+
+    def on_props_change(self, payload: dict[str, Any], flow: "ReactFlow") -> None:
+        """Hook called when this node's top-level properties change."""
 
     def on_selection_changed(self, payload: dict[str, Any], flow: "ReactFlow") -> None:
         """Hook called when this node participates in a selection update."""
@@ -896,7 +934,48 @@ class EdgeSpec:
 
 
 class Edge(param.Parameterized):
-    """Base class for object-oriented edges."""
+    """Base class for object-oriented edges.
+
+    Assigning to a parameter after the edge is part of a graph updates the
+    browser in place, without re-serializing the whole ``ReactFlow.edges``
+    list. Parameters declared on a subclass are synced into the edge's
+    ``data``; the base parameters listed in ``_synced_props`` are synced as
+    top-level React Flow fields.
+    """
+
+    # Fields ``to_dict`` serializes outside ``data``, i.e. the ones
+    # ``ReactFlow.patch_edge_props`` may update in place.
+    _props = (
+        "source",
+        "target",
+        "label",
+        "type",
+        "selected",
+        "style",
+        "markerEnd",
+        "sourceHandle",
+        "targetHandle",
+    )
+
+    # Subset of ``_props`` pushed to the browser on assignment. ``selected``
+    # is driven by the frontend while the user selects, so echoing it back
+    # would fight the pointer; use ``ReactFlow.patch_edge_props`` to set it.
+    _synced_props = (
+        "source",
+        "target",
+        "label",
+        "type",
+        "style",
+        "markerEnd",
+        "sourceHandle",
+        "targetHandle",
+    )
+
+    # ``data`` keys ``ReactFlow.patch_edge_data`` mirrors onto a top-level
+    # property. The frontend has always promoted a patched label onto the edge
+    # itself, so the parameter has to follow or the next full serialization
+    # reverts it.
+    _mirrored_data_keys = {"label": "label"}
 
     id = param.String(default="", doc="Unique edge identifier.")
     source = param.String(default="", doc="Source node id.")
@@ -910,10 +989,6 @@ class Edge(param.Parameterized):
     sourceHandle = param.String(default=None, allow_None=True, doc="Optional source handle id.")
     targetHandle = param.String(default=None, allow_None=True, doc="Optional target handle id.")
     flow = param.Parameter(default=None, allow_None=True, precedence=-1, doc="Parent ReactFlow instance.")
-
-    #: Base params that map to top-level React Flow edge fields rather than
-    #: arbitrary ``data`` payload keys. See ``Node._TOP_LEVEL_SYNC_PARAMS``.
-    _TOP_LEVEL_SYNC_PARAMS: ClassVar[tuple[str, ...]] = ("label", "type", "style", "markerEnd", "sourceHandle", "targetHandle")
 
     @classmethod
     def _data_param_names(cls) -> list[str]:
@@ -965,6 +1040,9 @@ class Edge(param.Parameterized):
 
     def on_data_change(self, payload: dict[str, Any], flow: "ReactFlow") -> None:
         """Hook called when this edge's data changes."""
+
+    def on_props_change(self, payload: dict[str, Any], flow: "ReactFlow") -> None:
+        """Hook called when this edge's top-level properties change."""
 
     def on_selection_changed(self, payload: dict[str, Any], flow: "ReactFlow") -> None:
         """Hook called when this edge participates in a selection update."""
@@ -1524,6 +1602,7 @@ class ReactFlow(ReactComponent):
         self._attached_edge_instances: dict[int, Edge] = {}
         self._node_data_param_watchers: dict[str, tuple[Node, list[Any]]] = {}
         self._edge_data_param_watchers: dict[str, tuple[Edge, list[Any]]] = {}
+        self._suppress_prop_sync = False
         self._node_view_cache: dict[str, tuple[int, Any]] = {}
         # Normalize type specs before parent init so the frontend receives
         # JSON-serializable descriptors from the start.
@@ -1692,22 +1771,6 @@ class ReactFlow(ReactComponent):
             node["data"] = data
 
     @staticmethod
-    def _node_set_top_level(node: dict[str, Any] | Node, key: str, value: Any) -> None:
-        """Assign a top-level field (label/style/className) on a node.
-
-        For ``Node`` instances this sets the corresponding param, which is a
-        no-op if the value hasn't changed (avoiding re-triggering the param
-        watcher that calls back into ``patch_node_data``). For plain dicts,
-        ``None`` clears the field so it falls back to defaults.
-        """
-        if isinstance(node, Node):
-            setattr(node, key, value)
-        elif value is None:
-            node.pop(key, None)
-        else:
-            node[key] = value
-
-    @staticmethod
     def _node_payload(node: dict[str, Any] | NodeSpec | Node) -> dict[str, Any]:
         if isinstance(node, Node):
             return node.to_dict()
@@ -1744,20 +1807,6 @@ class ReactFlow(ReactComponent):
             edge.data = dict(data)
         else:
             edge["data"] = data
-
-    @staticmethod
-    def _edge_set_top_level(edge: dict[str, Any] | Edge, key: str, value: Any) -> None:
-        """Assign a top-level field (style/type/label/...) on an edge.
-
-        See ``_node_set_top_level`` for why ``Edge`` instances are safe from
-        watcher re-entrancy and why ``None`` clears the field on plain dicts.
-        """
-        if isinstance(edge, Edge):
-            setattr(edge, key, value)
-        elif value is None:
-            edge.pop(key, None)
-        else:
-            edge[key] = value
 
     @staticmethod
     def _edge_payload(edge: dict[str, Any] | EdgeSpec | Edge) -> dict[str, Any]:
@@ -1832,7 +1881,8 @@ class ReactFlow(ReactComponent):
             current_items=current_nodes,
             watcher_store=self._node_data_param_watchers,
             get_instance=self._get_node_instance,
-            patch_fn=self.patch_node_data,
+            data_patch_fn=self.patch_node_data,
+            prop_patch_fn=self.patch_node_props,
         )
 
     def _update_edge_data_param_watchers(self) -> None:
@@ -1841,7 +1891,8 @@ class ReactFlow(ReactComponent):
             current_items=current_edges,
             watcher_store=self._edge_data_param_watchers,
             get_instance=self._get_edge_instance,
-            patch_fn=self.patch_edge_data,
+            data_patch_fn=self.patch_edge_data,
+            prop_patch_fn=self.patch_edge_props,
         )
 
     def _update_param_watchers(
@@ -1850,16 +1901,16 @@ class ReactFlow(ReactComponent):
         current_items: dict[str, Node | Edge],
         watcher_store: dict[str, tuple[Node | Edge, list[Any]]],
         get_instance: Callable[[str], Node | Edge | None],
-        patch_fn: Callable[[str, dict[str, Any]], None],
+        data_patch_fn: Callable[[str, dict[str, Any]], None],
+        prop_patch_fn: Callable[[str, dict[str, Any]], None],
     ) -> None:
         """Keep param watchers for a set of live ``Node``/``Edge`` instances in sync.
 
-        Watches both subclass-defined data params (``item._data_param_names()``)
-        and the item's serializable base params (``item._TOP_LEVEL_SYNC_PARAMS``,
-        e.g. ``label``/``style``), so that assigning either on a live instance
-        pushes a patch to the frontend. ``patch_fn`` (``patch_node_data`` or
-        ``patch_edge_data``) already knows how to route each kind of param name
-        to the right place (``data`` vs. a top-level field).
+        Watches both the subclass-defined data params
+        (``item._data_param_names()``), which are patched into ``data``, and the
+        presentational base params (``item._synced_props``, e.g.
+        ``label``/``style``), which are patched as top-level React Flow fields,
+        so that assigning either on a live instance reaches the frontend.
         """
         for item_id, (watched_item, _) in list(watcher_store.items()):
             current = current_items.get(item_id)
@@ -1868,41 +1919,67 @@ class ReactFlow(ReactComponent):
         for item_id, item in current_items.items():
             if item_id in watcher_store:
                 continue
-            data_names = set(item._data_param_names())
-            names = [*data_names, *type(item)._TOP_LEVEL_SYNC_PARAMS]
             watchers = [
                 item.param.watch(
-                    lambda event, _id=item_id, _name=name, _item=item, _is_data=name in data_names: self._on_synced_param_change(
-                        get_instance, patch_fn, _id, _name, _item, event, _is_data
-                    ),
+                    lambda event, _id=item_id, _name=name, _item=item: self._on_data_param_change(get_instance, data_patch_fn, _id, _name, _item, event),
                     name,
                 )
-                for name in names
+                for name in item._data_param_names()
             ]
+            # A single watcher for every property, so that a batched
+            # ``param.update`` coalesces into one patch message.
+            watchers.append(
+                item.param.watch(
+                    lambda *events, _id=item_id, _item=item: self._on_prop_param_change(get_instance, prop_patch_fn, _id, _item, *events),
+                    list(item._synced_props),
+                )
+            )
             watcher_store[item_id] = (item, watchers)
 
     @staticmethod
-    def _on_synced_param_change(
+    def _on_data_param_change(
         get_instance: Callable[[str], Node | Edge | None],
         patch_fn: Callable[[str, dict[str, Any]], None],
         item_id: str,
         param_name: str,
         item: Node | Edge,
         event: param.parameterized.Event,
-        is_data_param: bool,
     ) -> None:
-        """Push a live param change on a ``Node``/``Edge`` instance to the frontend.
-
-        ``is_data_param`` distinguishes subclass data params (guarded against
-        redundant re-sends caused by ``_sync_*_data_params_from_data``) from
-        base top-level params (``label``/``style``/...), which aren't stored
-        in ``.data`` so no such guard applies.
-        """
         if get_instance(item_id) is not item:
             return
-        if is_data_param and (item.data or {}).get(param_name) == event.new:
+        # Guards against the redundant re-send ``_sync_*_data_params_from_data``
+        # would otherwise cause.
+        if (item.data or {}).get(param_name) == event.new:
             return
         patch_fn(item_id, {param_name: event.new})
+
+    def _on_prop_param_change(
+        self,
+        get_instance: Callable[[str], Node | Edge | None],
+        patch_fn: Callable[[str, dict[str, Any]], None],
+        item_id: str,
+        item: Node | Edge,
+        *events: param.parameterized.Event,
+    ) -> None:
+        if self._suppress_prop_sync:
+            return
+        if get_instance(item_id) is not item:
+            return
+        patch_fn(item_id, {event.name: event.new for event in events})
+
+    @contextmanager
+    def _suppressed_prop_sync(self):
+        """Apply values that came from (or are already in) the browser.
+
+        Prevents the ``Node``/``Edge`` property watchers from echoing a patch
+        back to the frontend for a value the frontend already holds.
+        """
+        previous = self._suppress_prop_sync
+        self._suppress_prop_sync = True
+        try:
+            yield
+        finally:
+            self._suppress_prop_sync = previous
 
     @staticmethod
     def _invoke_node_callback(callback: Callable, payload: dict[str, Any], flow: "ReactFlow") -> None:
@@ -1928,7 +2005,7 @@ class ReactFlow(ReactComponent):
             node_payload = payload.get("node", {})
             if isinstance(node_payload, dict) and node_payload.get("id"):
                 node_ids = [node_payload["id"]]
-        elif event_type in ("node_moved", "node_clicked", "node_data_changed"):
+        elif event_type in ("node_moved", "node_clicked", "node_data_changed", "node_props_changed"):
             node_id = payload.get("node_id")
             if node_id:
                 node_ids = [node_id]
@@ -1942,6 +2019,7 @@ class ReactFlow(ReactComponent):
             "node_moved": "on_move",
             "node_clicked": "on_click",
             "node_data_changed": "on_data_change",
+            "node_props_changed": "on_props_change",
             "selection_changed": "on_selection_changed",
             "sync": "on_sync",
         }
@@ -1960,7 +2038,7 @@ class ReactFlow(ReactComponent):
             edge_payload = payload.get("edge", {})
             if isinstance(edge_payload, dict) and edge_payload.get("id"):
                 edge_ids = [edge_payload["id"]]
-        elif event_type in ("edge_deleted", "edge_data_changed"):
+        elif event_type in ("edge_deleted", "edge_data_changed", "edge_props_changed"):
             edge_id = payload.get("edge_id")
             if edge_id:
                 edge_ids = [edge_id]
@@ -1973,6 +2051,7 @@ class ReactFlow(ReactComponent):
             "edge_added": "on_add",
             "edge_deleted": "on_delete",
             "edge_data_changed": "on_data_change",
+            "edge_props_changed": "on_props_change",
             "selection_changed": "on_selection_changed",
             "sync": "on_sync",
         }
@@ -2268,6 +2347,57 @@ class ReactFlow(ReactComponent):
         self.nodes = self.nodes + [raw_node if isinstance(raw_node, Node) else payload]
         self._emit("node_added", {"type": "node_added", "node": payload})
 
+    def _apply_sync(self, nodes: list[dict[str, Any]] | None, edges: list[dict[str, Any]] | None) -> None:
+        """Apply a full graph payload coming from the frontend."""
+        if nodes is not None:
+            node_instances = {node.id: node for node in self.nodes if isinstance(node, Node)}
+            synced_nodes: list[dict[str, Any] | Node] = []
+            for payload in nodes:
+                node = node_instances.get(payload.get("id"))
+                if node is None:
+                    synced_nodes.append(payload)
+                    continue
+                node.position = dict(payload.get("position", node.position))
+                node.type = payload.get("type", node.type)
+                node.label = payload.get("label", node.label)
+                node.data = dict(payload.get("data", node.data))
+                self._sync_node_data_params_from_data(node)
+                node.selected = payload.get("selected", node.selected)
+                node.draggable = payload.get("draggable", node.draggable)
+                node.connectable = payload.get("connectable", node.connectable)
+                node.deletable = payload.get("deletable", node.deletable)
+                if "style" in payload:
+                    node.style = payload.get("style")
+                if "className" in payload:
+                    node.className = payload.get("className")
+                synced_nodes.append(node)
+            self.nodes = synced_nodes
+        if edges is not None:
+            edge_instances = {edge.id: edge for edge in self.edges if isinstance(edge, Edge)}
+            synced_edges: list[dict[str, Any] | Edge] = []
+            for payload in edges:
+                edge = edge_instances.get(payload.get("id"))
+                if edge is None:
+                    synced_edges.append(payload)
+                    continue
+                edge.source = payload.get("source", edge.source)
+                edge.target = payload.get("target", edge.target)
+                edge.label = payload.get("label", edge.label)
+                edge.type = payload.get("type", edge.type)
+                edge.selected = payload.get("selected", edge.selected)
+                edge.data = dict(payload.get("data", edge.data))
+                self._sync_edge_data_params_from_data(edge)
+                if "style" in payload:
+                    edge.style = payload.get("style")
+                if "markerEnd" in payload:
+                    edge.markerEnd = payload.get("markerEnd")
+                if "sourceHandle" in payload:
+                    edge.sourceHandle = payload.get("sourceHandle")
+                if "targetHandle" in payload:
+                    edge.targetHandle = payload.get("targetHandle")
+                synced_edges.append(edge)
+            self.edges = synced_edges
+
     def _handle_msg(self, msg: dict[str, Any]) -> None:
         """Handle sync messages from the frontend."""
         if not isinstance(msg, dict):
@@ -2276,56 +2406,8 @@ class ReactFlow(ReactComponent):
             case "sync":
                 nodes = msg.get("nodes")
                 edges = msg.get("edges")
-                if nodes is not None:
-                    current_instances = {node.id: node for node in self.nodes if isinstance(node, Node)}
-                    synced_nodes: list[dict[str, Any] | Node] = []
-                    for payload in nodes:
-                        node_id = payload.get("id")
-                        if node_id in current_instances:
-                            node = current_instances[node_id]
-                            node.position = dict(payload.get("position", node.position))
-                            node.type = payload.get("type", node.type)
-                            node.label = payload.get("label", node.label)
-                            node.data = dict(payload.get("data", node.data))
-                            self._sync_node_data_params_from_data(node)
-                            node.selected = payload.get("selected", node.selected)
-                            node.draggable = payload.get("draggable", node.draggable)
-                            node.connectable = payload.get("connectable", node.connectable)
-                            node.deletable = payload.get("deletable", node.deletable)
-                            if "style" in payload:
-                                node.style = payload.get("style")
-                            if "className" in payload:
-                                node.className = payload.get("className")
-                            synced_nodes.append(node)
-                        else:
-                            synced_nodes.append(payload)
-                    self.nodes = synced_nodes
-                if edges is not None:
-                    current_instances = {edge.id: edge for edge in self.edges if isinstance(edge, Edge)}
-                    synced_edges: list[dict[str, Any] | Edge] = []
-                    for payload in edges:
-                        edge_id = payload.get("id")
-                        if edge_id in current_instances:
-                            edge = current_instances[edge_id]
-                            edge.source = payload.get("source", edge.source)
-                            edge.target = payload.get("target", edge.target)
-                            edge.label = payload.get("label", edge.label)
-                            edge.type = payload.get("type", edge.type)
-                            edge.selected = payload.get("selected", edge.selected)
-                            edge.data = dict(payload.get("data", edge.data))
-                            self._sync_edge_data_params_from_data(edge)
-                            if "style" in payload:
-                                edge.style = payload.get("style")
-                            if "markerEnd" in payload:
-                                edge.markerEnd = payload.get("markerEnd")
-                            if "sourceHandle" in payload:
-                                edge.sourceHandle = payload.get("sourceHandle")
-                            if "targetHandle" in payload:
-                                edge.targetHandle = payload.get("targetHandle")
-                            synced_edges.append(edge)
-                        else:
-                            synced_edges.append(payload)
-                    self.edges = synced_edges
+                with self._suppressed_prop_sync():
+                    self._apply_sync(nodes, edges)
                 self._emit("sync", msg)
             case "node_moved":
                 node_id = msg.get("node_id")
@@ -2602,40 +2684,31 @@ class ReactFlow(ReactComponent):
         items: list,
         item_id: str,
         patch: dict[str, Any],
-        top_level_params: tuple[str, ...],
         get_id: Callable[[Any], str | None],
         get_data: Callable[[Any], dict[str, Any]],
         set_data: Callable[[Any, dict[str, Any]], None],
-        set_top_level: Callable[[Any, str, Any], None],
         get_schema: Callable[[Any], dict[str, Any] | None],
         sync_from_data: Callable[[Any], None],
         instance_cls: type,
-    ) -> tuple[dict[str, Any], dict[str, Any]]:
+    ) -> None:
         """Shared implementation for ``patch_node_data``/``patch_edge_data``.
 
-        Splits ``patch`` into top-level fields (``label``/``style``/...,
-        see ``Node._TOP_LEVEL_SYNC_PARAMS``/``Edge._TOP_LEVEL_SYNC_PARAMS``)
-        and arbitrary ``data`` keys, applies each to the right place on the
-        matching item, and returns ``(top_patch, data_patch)`` so the caller
-        can forward that same split to the frontend.
+        Merges ``patch`` into the matching item's ``data``, validating it
+        against the item type's schema when ``validate_on_patch`` is enabled.
+        Top-level React Flow fields are patched separately, by
+        ``patch_node_props``/``patch_edge_props``.
         """
-        top_patch = {k: v for k, v in patch.items() if k in top_level_params}
-        data_patch = {k: v for k, v in patch.items() if k not in top_level_params}
         for item in items:
             if get_id(item) != item_id:
                 continue
-            if data_patch:
-                data = get_data(item)
-                data.update(data_patch)
-                if self.validate_on_patch:
-                    _validate_data(data, get_schema(item))
-                set_data(item, data)
-                if isinstance(item, instance_cls):
-                    sync_from_data(item)
-            for key, value in top_patch.items():
-                set_top_level(item, key, value)
+            data = get_data(item)
+            data.update(patch)
+            if self.validate_on_patch:
+                _validate_data(data, get_schema(item))
+            set_data(item, data)
+            if isinstance(item, instance_cls):
+                sync_from_data(item)
             break
-        return top_patch, data_patch
 
     def patch_node_data(self, node_id: str, patch: dict[str, Any]) -> None:
         """Update specific properties in a node's data dictionary.
@@ -2685,29 +2758,33 @@ class ReactFlow(ReactComponent):
         modify node properties in the UI. The patch is also sent to the
         frontend to keep the visualization in sync.
 
+        A ``label`` (or ``_label``) key is kept in ``data`` *and* mirrored onto
+        the node's top-level label, since that is where the node components
+        read it from. Every other key is treated as opaque data; use
+        :meth:`patch_node_props` for the remaining presentational fields.
+
         See Also
         --------
         patch_edge_data : Update edge data properties
+        patch_node_props : Update top-level node properties
         add_node : Add a new node to the graph
         """
-        top_patch, data_patch = self._apply_data_patch(
+        self._apply_data_patch(
             items=self.nodes,
             item_id=node_id,
             patch=patch,
-            top_level_params=Node._TOP_LEVEL_SYNC_PARAMS,
             get_id=self._node_id,
             get_data=self._node_data,
             set_data=self._node_set_data,
-            set_top_level=self._node_set_top_level,
             get_schema=lambda node: self._get_node_schema(self._node_type(node)),
             sync_from_data=self._sync_node_data_params_from_data,
             instance_cls=Node,
         )
-        # `top_patch`/`data_patch` tell the frontend exactly where each key
-        # belongs (top-level node field vs. `data`), so it doesn't need its
-        # own copy of which keys are "top-level" to stay in sync with here.
-        self._send_msg({"type": "patch_node_data", "node_id": node_id, "patch": data_patch, "top_patch": top_patch})
+        self._send_msg({"type": "patch_node_data", "node_id": node_id, "patch": patch})
         self._emit("node_data_changed", {"type": "node_data_changed", "node_id": node_id, "patch": patch})
+        mirrored = self._mirrored_props(patch, Node._mirrored_data_keys)
+        if mirrored:
+            self.patch_node_props(node_id, mirrored)
 
     def patch_edge_data(self, edge_id: str, patch: dict[str, Any]) -> None:
         """Update specific properties in an edge's data dictionary.
@@ -2751,26 +2828,165 @@ class ReactFlow(ReactComponent):
         modify edge properties in the UI. The patch is also sent to the
         frontend to keep the visualization in sync.
 
+        A ``label`` key is kept in ``data`` *and* mirrored onto the edge's
+        top-level label, which is what React Flow renders. Every other key is
+        treated as opaque data; use :meth:`patch_edge_props` for the remaining
+        presentational fields.
+
         See Also
         --------
         patch_node_data : Update node data properties
+        patch_edge_props : Update top-level edge properties
         add_edge : Add a new edge to the graph
         """
-        top_patch, data_patch = self._apply_data_patch(
+        self._apply_data_patch(
             items=self.edges,
             item_id=edge_id,
             patch=patch,
-            top_level_params=Edge._TOP_LEVEL_SYNC_PARAMS,
             get_id=self._edge_id,
             get_data=self._edge_data,
             set_data=self._edge_set_data,
-            set_top_level=self._edge_set_top_level,
             get_schema=lambda edge: self._get_edge_schema(self._edge_type(edge)) if self._edge_type(edge) else None,
             sync_from_data=self._sync_edge_data_params_from_data,
             instance_cls=Edge,
         )
-        self._send_msg({"type": "patch_edge_data", "edge_id": edge_id, "patch": data_patch, "top_patch": top_patch})
+        self._send_msg({"type": "patch_edge_data", "edge_id": edge_id, "patch": patch})
         self._emit("edge_data_changed", {"type": "edge_data_changed", "edge_id": edge_id, "patch": patch})
+        mirrored = self._mirrored_props(patch, Edge._mirrored_data_keys)
+        if mirrored:
+            self.patch_edge_props(edge_id, mirrored)
+
+    @staticmethod
+    def _mirrored_props(patch: dict[str, Any], mirrored: dict[str, str]) -> dict[str, Any]:
+        return {prop: patch[key] for key, prop in mirrored.items() if key in patch}
+
+    def _validate_prop_patch(self, patch: dict[str, Any], *, kind: str, allowed: tuple[str, ...]) -> None:
+        unknown = [key for key in patch if key not in allowed]
+        if not unknown:
+            return
+        hint = f"Use patch_{kind}_data to update the {kind}'s data dictionary."
+        prop_name = "property" if len(unknown) == 1 else "properties"
+        raise ValueError(f"Cannot patch {kind} {prop_name} {unknown!r}; expected one of {list(allowed)!r}. {hint}")
+
+    def _apply_prop_patch(self, obj: dict[str, Any] | Node | Edge, patch: dict[str, Any]) -> None:
+        """Apply a top-level property patch to the Python-side node/edge."""
+        if isinstance(obj, (Node, Edge)):
+            # The watchers already sent (or are about to send) the patch, so
+            # applying it here must not trigger a second message.
+            with self._suppressed_prop_sync():
+                for key, value in patch.items():
+                    setattr(obj, key, value)
+        else:
+            for key, value in patch.items():
+                if value is None:
+                    obj.pop(key, None)
+                else:
+                    obj[key] = value
+
+    def patch_node_props(self, node_id: str, patch: dict[str, Any]) -> None:
+        """Update top-level properties of a node.
+
+        Sends an incremental patch to the frontend, updating fields that live
+        outside the node's ``data`` dictionary (``label``, ``style``, ``type``,
+        ``position``, ...) without re-serializing the whole ``nodes`` list.
+
+        Assigning to the corresponding parameter of a :class:`Node` instance
+        calls this method for you, so this is mainly useful for nodes defined
+        as plain dictionaries and for the frontend-driven ``position`` and
+        ``selected`` fields.
+
+        Parameters
+        ----------
+        node_id : str
+            Unique identifier of the node to update.
+        patch : dict
+            Mapping of property names to new values. Supported keys are
+            ``position``, ``type``, ``label``, ``selected``, ``draggable``,
+            ``connectable``, ``deletable``, ``style`` and ``className``.
+            Passing ``None`` clears the property so the node falls back to
+            the CSS/theme default.
+
+        Raises
+        ------
+        ValueError
+            If *patch* contains a key that is not a top-level node property.
+
+        Examples
+        --------
+        Restyle a node and rename it:
+
+        >>> flow.patch_node_props("n1", {"style": {"border": "2px solid red"}, "label": "Failed"})
+
+        Clear a style so the theme default applies again:
+
+        >>> flow.patch_node_props("n1", {"style": None})
+
+        Move a node programmatically:
+
+        >>> flow.patch_node_props("n1", {"position": {"x": 120, "y": 40}})
+
+        See Also
+        --------
+        patch_node_data : Update the node's ``data`` dictionary
+        patch_edge_props : Update top-level edge properties
+        """
+        self._validate_prop_patch(patch, kind="node", allowed=Node._props)
+        for node in self.nodes:
+            if self._node_id(node) == node_id:
+                self._apply_prop_patch(node, patch)
+                break
+        self._send_msg({"type": "patch_node_props", "node_id": node_id, "patch": patch})
+        self._emit("node_props_changed", {"type": "node_props_changed", "node_id": node_id, "patch": patch})
+
+    def patch_edge_props(self, edge_id: str, patch: dict[str, Any]) -> None:
+        """Update top-level properties of an edge.
+
+        Sends an incremental patch to the frontend, updating fields that live
+        outside the edge's ``data`` dictionary (``label``, ``style``, ``type``,
+        ``markerEnd``, ...) without re-serializing the whole ``edges`` list.
+
+        Assigning to the corresponding parameter of an :class:`Edge` instance
+        calls this method for you, so this is mainly useful for edges defined
+        as plain dictionaries and for the frontend-driven ``selected`` field.
+
+        Parameters
+        ----------
+        edge_id : str
+            Unique identifier of the edge to update.
+        patch : dict
+            Mapping of property names to new values. Supported keys are
+            ``source``, ``target``, ``label``, ``type``, ``selected``,
+            ``style``, ``markerEnd``, ``sourceHandle`` and ``targetHandle``.
+            Passing ``None`` clears the property so the edge falls back to
+            the CSS/theme default.
+
+        Raises
+        ------
+        ValueError
+            If *patch* contains a key that is not a top-level edge property.
+
+        Examples
+        --------
+        Highlight an edge and switch it to a step router:
+
+        >>> flow.patch_edge_props("e1", {"style": {"stroke": "#ef4444", "strokeWidth": 6}, "type": "step"})
+
+        Clear the style so the theme default applies again:
+
+        >>> flow.patch_edge_props("e1", {"style": None})
+
+        See Also
+        --------
+        patch_edge_data : Update the edge's ``data`` dictionary
+        patch_node_props : Update top-level node properties
+        """
+        self._validate_prop_patch(patch, kind="edge", allowed=Edge._props)
+        for edge in self.edges:
+            if self._edge_id(edge) == edge_id:
+                self._apply_prop_patch(edge, patch)
+                break
+        self._send_msg({"type": "patch_edge_props", "edge_id": edge_id, "patch": patch})
+        self._emit("edge_props_changed", {"type": "edge_props_changed", "edge_id": edge_id, "patch": patch})
 
     def to_networkx(self, *, multigraph: bool = False):
         """Convert the current graph to NetworkX format.
@@ -3037,9 +3253,13 @@ class ReactFlow(ReactComponent):
             - ``"node_moved"``: Node was dragged to a new position
             - ``"node_clicked"``: Node was clicked
             - ``"node_data_changed"``: Node data was modified
+            - ``"node_props_changed"``: Top-level node properties (``label``,
+              ``style``, ``type``, ...) were modified
             - ``"edge_added"``: Edge was added to the graph
             - ``"edge_deleted"``: Edge was removed from the graph
             - ``"edge_data_changed"``: Edge data was modified
+            - ``"edge_props_changed"``: Top-level edge properties (``label``,
+              ``style``, ``type``, ...) were modified
             - ``"selection_changed"``: Selection changed
             - ``"sync"``: Full graph sync from frontend
             - ``"client_error"``: The graph view hit a rendering error in the

--- a/src/panel_reactflow/base.py
+++ b/src/panel_reactflow/base.py
@@ -11,7 +11,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from functools import partial
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, ClassVar, Literal
 from uuid import uuid4
 
 import panel as pn
@@ -645,6 +645,12 @@ class Node(param.Parameterized):
     className = param.String(default=None, allow_None=True, doc="Optional CSS class.")
     flow = param.Parameter(default=None, allow_None=True, precedence=-1, doc="Parent ReactFlow instance.")
 
+    #: Base params that map to top-level React Flow node fields rather than
+    #: arbitrary ``data`` payload keys. Assigning one of these on a live
+    #: ``Node`` instance is watched and synced to the frontend, just like
+    #: subclass-defined data params (see ``_data_param_names``).
+    _TOP_LEVEL_SYNC_PARAMS: ClassVar[tuple[str, ...]] = ("label", "style", "className")
+
     @classmethod
     def _data_param_names(cls) -> list[str]:
         return _parameterized_data_param_names(cls, Node)
@@ -904,6 +910,10 @@ class Edge(param.Parameterized):
     sourceHandle = param.String(default=None, allow_None=True, doc="Optional source handle id.")
     targetHandle = param.String(default=None, allow_None=True, doc="Optional target handle id.")
     flow = param.Parameter(default=None, allow_None=True, precedence=-1, doc="Parent ReactFlow instance.")
+
+    #: Base params that map to top-level React Flow edge fields rather than
+    #: arbitrary ``data`` payload keys. See ``Node._TOP_LEVEL_SYNC_PARAMS``.
+    _TOP_LEVEL_SYNC_PARAMS: ClassVar[tuple[str, ...]] = ("label", "type", "style", "markerEnd", "sourceHandle", "targetHandle")
 
     @classmethod
     def _data_param_names(cls) -> list[str]:
@@ -1682,6 +1692,22 @@ class ReactFlow(ReactComponent):
             node["data"] = data
 
     @staticmethod
+    def _node_set_top_level(node: dict[str, Any] | Node, key: str, value: Any) -> None:
+        """Assign a top-level field (label/style/className) on a node.
+
+        For ``Node`` instances this sets the corresponding param, which is a
+        no-op if the value hasn't changed (avoiding re-triggering the param
+        watcher that calls back into ``patch_node_data``). For plain dicts,
+        ``None`` clears the field so it falls back to defaults.
+        """
+        if isinstance(node, Node):
+            setattr(node, key, value)
+        elif value is None:
+            node.pop(key, None)
+        else:
+            node[key] = value
+
+    @staticmethod
     def _node_payload(node: dict[str, Any] | NodeSpec | Node) -> dict[str, Any]:
         if isinstance(node, Node):
             return node.to_dict()
@@ -1720,6 +1746,20 @@ class ReactFlow(ReactComponent):
             edge["data"] = data
 
     @staticmethod
+    def _edge_set_top_level(edge: dict[str, Any] | Edge, key: str, value: Any) -> None:
+        """Assign a top-level field (style/type/label/...) on an edge.
+
+        See ``_node_set_top_level`` for why ``Edge`` instances are safe from
+        watcher re-entrancy and why ``None`` clears the field on plain dicts.
+        """
+        if isinstance(edge, Edge):
+            setattr(edge, key, value)
+        elif value is None:
+            edge.pop(key, None)
+        else:
+            edge[key] = value
+
+    @staticmethod
     def _edge_payload(edge: dict[str, Any] | EdgeSpec | Edge) -> dict[str, Any]:
         if isinstance(edge, Edge):
             return edge.to_dict()
@@ -1751,25 +1791,15 @@ class ReactFlow(ReactComponent):
             if name in (edge.data or {}):
                 setattr(edge, name, edge.data[name])
 
-    def _teardown_node_data_param_watcher(self, node_id: str) -> None:
-        record = self._node_data_param_watchers.pop(node_id, None)
+    @staticmethod
+    def _teardown_param_watcher(watcher_store: dict[str, tuple[Any, list[Any]]], item_id: str) -> None:
+        record = watcher_store.pop(item_id, None)
         if record is None:
             return
-        node, watchers = record
+        item, watchers = record
         for watcher in watchers:
             try:
-                node.param.unwatch(watcher)
-            except Exception:
-                pass
-
-    def _teardown_edge_data_param_watcher(self, edge_id: str) -> None:
-        record = self._edge_data_param_watchers.pop(edge_id, None)
-        if record is None:
-            return
-        edge, watchers = record
-        for watcher in watchers:
-            try:
-                edge.param.unwatch(watcher)
+                item.param.unwatch(watcher)
             except Exception:
                 pass
 
@@ -1798,67 +1828,81 @@ class ReactFlow(ReactComponent):
 
     def _update_node_data_param_watchers(self) -> None:
         current_nodes = {node.id: node for node in self.nodes if isinstance(node, Node) and node.id}
-        for node_id, (watched_node, _) in list(self._node_data_param_watchers.items()):
-            current = current_nodes.get(node_id)
-            if current is None or current is not watched_node:
-                self._teardown_node_data_param_watcher(node_id)
-        for node_id, node in current_nodes.items():
-            if node_id in self._node_data_param_watchers:
-                continue
-            watchers = []
-            for name in node._data_param_names():
-                watchers.append(
-                    node.param.watch(
-                        lambda event, _id=node_id, _name=name, _node=node: self._on_node_data_param_change(_id, _name, _node, event),
-                        name,
-                    )
-                )
-            self._node_data_param_watchers[node_id] = (node, watchers)
+        self._update_param_watchers(
+            current_items=current_nodes,
+            watcher_store=self._node_data_param_watchers,
+            get_instance=self._get_node_instance,
+            patch_fn=self.patch_node_data,
+        )
 
     def _update_edge_data_param_watchers(self) -> None:
         current_edges = {edge.id: edge for edge in self.edges if isinstance(edge, Edge) and edge.id}
-        for edge_id, (watched_edge, _) in list(self._edge_data_param_watchers.items()):
-            current = current_edges.get(edge_id)
-            if current is None or current is not watched_edge:
-                self._teardown_edge_data_param_watcher(edge_id)
-        for edge_id, edge in current_edges.items():
-            if edge_id in self._edge_data_param_watchers:
+        self._update_param_watchers(
+            current_items=current_edges,
+            watcher_store=self._edge_data_param_watchers,
+            get_instance=self._get_edge_instance,
+            patch_fn=self.patch_edge_data,
+        )
+
+    def _update_param_watchers(
+        self,
+        *,
+        current_items: dict[str, Node | Edge],
+        watcher_store: dict[str, tuple[Node | Edge, list[Any]]],
+        get_instance: Callable[[str], Node | Edge | None],
+        patch_fn: Callable[[str, dict[str, Any]], None],
+    ) -> None:
+        """Keep param watchers for a set of live ``Node``/``Edge`` instances in sync.
+
+        Watches both subclass-defined data params (``item._data_param_names()``)
+        and the item's serializable base params (``item._TOP_LEVEL_SYNC_PARAMS``,
+        e.g. ``label``/``style``), so that assigning either on a live instance
+        pushes a patch to the frontend. ``patch_fn`` (``patch_node_data`` or
+        ``patch_edge_data``) already knows how to route each kind of param name
+        to the right place (``data`` vs. a top-level field).
+        """
+        for item_id, (watched_item, _) in list(watcher_store.items()):
+            current = current_items.get(item_id)
+            if current is None or current is not watched_item:
+                self._teardown_param_watcher(watcher_store, item_id)
+        for item_id, item in current_items.items():
+            if item_id in watcher_store:
                 continue
-            watchers = []
-            for name in edge._data_param_names():
-                watchers.append(
-                    edge.param.watch(
-                        lambda event, _id=edge_id, _name=name, _edge=edge: self._on_edge_data_param_change(_id, _name, _edge, event),
-                        name,
-                    )
+            data_names = set(item._data_param_names())
+            names = [*data_names, *type(item)._TOP_LEVEL_SYNC_PARAMS]
+            watchers = [
+                item.param.watch(
+                    lambda event, _id=item_id, _name=name, _item=item, _is_data=name in data_names: self._on_synced_param_change(
+                        get_instance, patch_fn, _id, _name, _item, event, _is_data
+                    ),
+                    name,
                 )
-            self._edge_data_param_watchers[edge_id] = (edge, watchers)
+                for name in names
+            ]
+            watcher_store[item_id] = (item, watchers)
 
-    def _on_node_data_param_change(
-        self,
-        node_id: str,
+    @staticmethod
+    def _on_synced_param_change(
+        get_instance: Callable[[str], Node | Edge | None],
+        patch_fn: Callable[[str, dict[str, Any]], None],
+        item_id: str,
         param_name: str,
-        node: Node,
+        item: Node | Edge,
         event: param.parameterized.Event,
+        is_data_param: bool,
     ) -> None:
-        if self._get_node_instance(node_id) is not node:
-            return
-        if (node.data or {}).get(param_name) == event.new:
-            return
-        self.patch_node_data(node_id, {param_name: event.new})
+        """Push a live param change on a ``Node``/``Edge`` instance to the frontend.
 
-    def _on_edge_data_param_change(
-        self,
-        edge_id: str,
-        param_name: str,
-        edge: Edge,
-        event: param.parameterized.Event,
-    ) -> None:
-        if self._get_edge_instance(edge_id) is not edge:
+        ``is_data_param`` distinguishes subclass data params (guarded against
+        redundant re-sends caused by ``_sync_*_data_params_from_data``) from
+        base top-level params (``label``/``style``/...), which aren't stored
+        in ``.data`` so no such guard applies.
+        """
+        if get_instance(item_id) is not item:
             return
-        if (edge.data or {}).get(param_name) == event.new:
+        if is_data_param and (item.data or {}).get(param_name) == event.new:
             return
-        self.patch_edge_data(edge_id, {param_name: event.new})
+        patch_fn(item_id, {param_name: event.new})
 
     @staticmethod
     def _invoke_node_callback(callback: Callable, payload: dict[str, Any], flow: "ReactFlow") -> None:
@@ -2552,6 +2596,47 @@ class ReactFlow(ReactComponent):
             self._invoke_edge_hook(removed_edge, "on_delete", payload)
             self._invoke_edge_hook(removed_edge, "on_event", payload)
 
+    def _apply_data_patch(
+        self,
+        *,
+        items: list,
+        item_id: str,
+        patch: dict[str, Any],
+        top_level_params: tuple[str, ...],
+        get_id: Callable[[Any], str | None],
+        get_data: Callable[[Any], dict[str, Any]],
+        set_data: Callable[[Any, dict[str, Any]], None],
+        set_top_level: Callable[[Any, str, Any], None],
+        get_schema: Callable[[Any], dict[str, Any] | None],
+        sync_from_data: Callable[[Any], None],
+        instance_cls: type,
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        """Shared implementation for ``patch_node_data``/``patch_edge_data``.
+
+        Splits ``patch`` into top-level fields (``label``/``style``/...,
+        see ``Node._TOP_LEVEL_SYNC_PARAMS``/``Edge._TOP_LEVEL_SYNC_PARAMS``)
+        and arbitrary ``data`` keys, applies each to the right place on the
+        matching item, and returns ``(top_patch, data_patch)`` so the caller
+        can forward that same split to the frontend.
+        """
+        top_patch = {k: v for k, v in patch.items() if k in top_level_params}
+        data_patch = {k: v for k, v in patch.items() if k not in top_level_params}
+        for item in items:
+            if get_id(item) != item_id:
+                continue
+            if data_patch:
+                data = get_data(item)
+                data.update(data_patch)
+                if self.validate_on_patch:
+                    _validate_data(data, get_schema(item))
+                set_data(item, data)
+                if isinstance(item, instance_cls):
+                    sync_from_data(item)
+            for key, value in top_patch.items():
+                set_top_level(item, key, value)
+            break
+        return top_patch, data_patch
+
     def patch_node_data(self, node_id: str, patch: dict[str, Any]) -> None:
         """Update specific properties in a node's data dictionary.
 
@@ -2605,18 +2690,23 @@ class ReactFlow(ReactComponent):
         patch_edge_data : Update edge data properties
         add_node : Add a new node to the graph
         """
-        for node in self.nodes:
-            if self._node_id(node) == node_id:
-                data = self._node_data(node)
-                data.update(patch)
-                if self.validate_on_patch:
-                    schema = self._get_node_schema(self._node_type(node))
-                    _validate_data(data, schema)
-                self._node_set_data(node, data)
-                if isinstance(node, Node):
-                    self._sync_node_data_params_from_data(node)
-                break
-        self._send_msg({"type": "patch_node_data", "node_id": node_id, "patch": patch})
+        top_patch, data_patch = self._apply_data_patch(
+            items=self.nodes,
+            item_id=node_id,
+            patch=patch,
+            top_level_params=Node._TOP_LEVEL_SYNC_PARAMS,
+            get_id=self._node_id,
+            get_data=self._node_data,
+            set_data=self._node_set_data,
+            set_top_level=self._node_set_top_level,
+            get_schema=lambda node: self._get_node_schema(self._node_type(node)),
+            sync_from_data=self._sync_node_data_params_from_data,
+            instance_cls=Node,
+        )
+        # `top_patch`/`data_patch` tell the frontend exactly where each key
+        # belongs (top-level node field vs. `data`), so it doesn't need its
+        # own copy of which keys are "top-level" to stay in sync with here.
+        self._send_msg({"type": "patch_node_data", "node_id": node_id, "patch": data_patch, "top_patch": top_patch})
         self._emit("node_data_changed", {"type": "node_data_changed", "node_id": node_id, "patch": patch})
 
     def patch_edge_data(self, edge_id: str, patch: dict[str, Any]) -> None:
@@ -2666,19 +2756,20 @@ class ReactFlow(ReactComponent):
         patch_node_data : Update node data properties
         add_edge : Add a new edge to the graph
         """
-        for edge in self.edges:
-            if self._edge_id(edge) == edge_id:
-                data = self._edge_data(edge)
-                data.update(patch)
-                if self.validate_on_patch:
-                    edge_type = self._edge_type(edge)
-                    schema = self._get_edge_schema(edge_type) if edge_type else None
-                    _validate_data(data, schema)
-                self._edge_set_data(edge, data)
-                if isinstance(edge, Edge):
-                    self._sync_edge_data_params_from_data(edge)
-                break
-        self._send_msg({"type": "patch_edge_data", "edge_id": edge_id, "patch": patch})
+        top_patch, data_patch = self._apply_data_patch(
+            items=self.edges,
+            item_id=edge_id,
+            patch=patch,
+            top_level_params=Edge._TOP_LEVEL_SYNC_PARAMS,
+            get_id=self._edge_id,
+            get_data=self._edge_data,
+            set_data=self._edge_set_data,
+            set_top_level=self._edge_set_top_level,
+            get_schema=lambda edge: self._get_edge_schema(self._edge_type(edge)) if self._edge_type(edge) else None,
+            sync_from_data=self._sync_edge_data_params_from_data,
+            instance_cls=Edge,
+        )
+        self._send_msg({"type": "patch_edge_data", "edge_id": edge_id, "patch": data_patch, "top_patch": top_patch})
         self._emit("edge_data_changed", {"type": "edge_data_changed", "edge_id": edge_id, "patch": patch})
 
     def to_networkx(self, *, multigraph: bool = False):

--- a/src/panel_reactflow/models/reactflow.jsx
+++ b/src/panel_reactflow/models/reactflow.jsx
@@ -18,6 +18,23 @@ const viewWrapperClassName = "rf-node-view-wrapper rf-node-view-wrapper--bokeh-s
 // stop retrying and hand control to the user.
 const SAFE_MODE_ATTEMPT = 2;
 const MAX_RECOVERY_ATTEMPTS = 2;
+
+// Apply a `top_patch` (from a patch_node_data/patch_edge_data message) onto
+// a React Flow node/edge object. Python already decides which keys are
+// top-level vs. `data` (see `_apply_data_patch` in base.py) and sends them
+// as separate `patch`/`top_patch` dicts, so this stays generic: any
+// `null`/`undefined` value clears the field (mirrors `_node_set_top_level`/
+// `_edge_set_top_level` treating `None` as "remove"), anything else is
+// assigned directly.
+function applyTopLevelPatch(target, topPatch) {
+  for (const [key, value] of Object.entries(topPatch || {})) {
+    if (value === null || value === undefined) {
+      delete target[key];
+    } else {
+      target[key] = value;
+    }
+  }
+}
 const RETRY_DELAY_MS = 100;
 // How long a remounted flow must survive before its retry budget is refilled.
 const HEALTHY_RESET_MS = 5000;
@@ -498,8 +515,15 @@ function FlowInner({
             if (node.id !== msg.node_id) {
               return node;
             }
-            const data = { ...(node.data || {}), ...(msg.patch || {}) };
-            return { ...node, data };
+            const topPatch = msg.top_patch || {};
+            const next = { ...node, data: { ...(node.data || {}), ...(msg.patch || {}) } };
+            applyTopLevelPatch(next, topPatch);
+            if ("label" in topPatch) {
+              // Node rendering reads the label from `data._label`, not the
+              // top-level `label` field directly (see makeNodeComponent).
+              next.data = { ...next.data, _label: topPatch.label };
+            }
+            return next;
           }),
         );
         return;
@@ -510,9 +534,9 @@ function FlowInner({
             if (edge.id !== msg.edge_id) {
               return edge;
             }
-            const data = { ...(edge.data || {}), ...(msg.patch || {}) };
-            const nextLabel = msg.patch?.label ?? edge.label;
-            return { ...edge, data, label: nextLabel };
+            const next = { ...edge, data: { ...(edge.data || {}), ...(msg.patch || {}) } };
+            applyTopLevelPatch(next, msg.top_patch || {});
+            return next;
           }),
         );
       }

--- a/src/panel_reactflow/models/reactflow.jsx
+++ b/src/panel_reactflow/models/reactflow.jsx
@@ -18,23 +18,6 @@ const viewWrapperClassName = "rf-node-view-wrapper rf-node-view-wrapper--bokeh-s
 // stop retrying and hand control to the user.
 const SAFE_MODE_ATTEMPT = 2;
 const MAX_RECOVERY_ATTEMPTS = 2;
-
-// Apply a `top_patch` (from a patch_node_data/patch_edge_data message) onto
-// a React Flow node/edge object. Python already decides which keys are
-// top-level vs. `data` (see `_apply_data_patch` in base.py) and sends them
-// as separate `patch`/`top_patch` dicts, so this stays generic: any
-// `null`/`undefined` value clears the field (mirrors `_node_set_top_level`/
-// `_edge_set_top_level` treating `None` as "remove"), anything else is
-// assigned directly.
-function applyTopLevelPatch(target, topPatch) {
-  for (const [key, value] of Object.entries(topPatch || {})) {
-    if (value === null || value === undefined) {
-      delete target[key];
-    } else {
-      target[key] = value;
-    }
-  }
-}
 const RETRY_DELAY_MS = 100;
 // How long a remounted flow must survive before its retry budget is refilled.
 const HEALTHY_RESET_MS = 5000;
@@ -269,6 +252,32 @@ function signature(value) {
   } catch (error) {
     return null;
   }
+}
+
+/**
+ * Combine the class React Flow needs for its own node chrome with the class
+ * declared on the Python side.
+ */
+function nodeClassName(type, className, model) {
+  const base = (type === "panel" || model.stylesheets.length > 7) ? "" : "react-flow__node-default";
+  return [base, className].filter(Boolean).join(" ");
+}
+
+/**
+ * Merge a patch of top-level fields (`style`, `type`, `label`, ...) into a node
+ * or edge. `null` removes the field so the element falls back to the CSS/theme
+ * default, mirroring how Python omits `None` when it serializes the graph.
+ */
+function applyPropPatch(element, patch) {
+  const next = { ...element };
+  Object.entries(patch || {}).forEach(([key, value]) => {
+    if (value === null) {
+      delete next[key];
+    } else {
+      next[key] = value;
+    }
+  });
+  return next;
 }
 
 /**
@@ -515,15 +524,8 @@ function FlowInner({
             if (node.id !== msg.node_id) {
               return node;
             }
-            const topPatch = msg.top_patch || {};
-            const next = { ...node, data: { ...(node.data || {}), ...(msg.patch || {}) } };
-            applyTopLevelPatch(next, topPatch);
-            if ("label" in topPatch) {
-              // Node rendering reads the label from `data._label`, not the
-              // top-level `label` field directly (see makeNodeComponent).
-              next.data = { ...next.data, _label: topPatch.label };
-            }
-            return next;
+            const data = { ...(node.data || {}), ...(msg.patch || {}) };
+            return { ...node, data };
           }),
         );
         return;
@@ -534,10 +536,38 @@ function FlowInner({
             if (edge.id !== msg.edge_id) {
               return edge;
             }
-            const next = { ...edge, data: { ...(edge.data || {}), ...(msg.patch || {}) } };
-            applyTopLevelPatch(next, msg.top_patch || {});
+            const data = { ...(edge.data || {}), ...(msg.patch || {}) };
+            const nextLabel = msg.patch?.label ?? edge.label;
+            return { ...edge, data, label: nextLabel };
+          }),
+        );
+        return;
+      }
+      if (msg.type === "patch_node_props") {
+        const patch = msg.patch || {};
+        setNodes((current) =>
+          current.map((node) => {
+            if (node.id !== msg.node_id) {
+              return node;
+            }
+            const next = applyPropPatch(node, patch);
+            if ("label" in patch) {
+              // The node components render `data._label`, not the top-level label.
+              next.data = { ...(next.data || {}), _label: patch.label };
+            }
+            if ("className" in patch || "type" in patch) {
+              const declared = "className" in patch ? patch.className : node._className;
+              next._className = declared ?? null;
+              next.className = nodeClassName(next.type, declared, model);
+            }
             return next;
           }),
+        );
+        return;
+      }
+      if (msg.type === "patch_edge_props") {
+        setEdges((current) =>
+          current.map((edge) => (edge.id === msg.edge_id ? applyPropPatch(edge, msg.patch) : edge)),
         );
       }
     };
@@ -1004,7 +1034,10 @@ export function render({ model, view }) {
       const hasEditor = realKeys.length > 0 || !!typeSpec.schema;
       return {
         ...node,
-        className: (node.type === "panel" || model.stylesheets.length > 7) ? "" : "react-flow__node-default",
+        // Keep the declared class around so a later className/type patch can
+        // recombine it with the React Flow node chrome class.
+        _className: node.className ?? null,
+        className: nodeClassName(node.type, node.className, model),
         data: {
           ...dataWithoutViewIdx,
           view: baseView,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -300,7 +300,11 @@ def test_patch_edge_data_updates_edge_instance() -> None:
     )
     flow.patch_edge_data("e1", {"weight": 3, "label": "hi"})
     assert edge.data["weight"] == 3
-    assert edge.data["label"] == "hi"
+    # `label` is a top-level Edge field, not part of `data` (see
+    # panel-multi#60); it should land on `edge.label` and must not leak
+    # into `data` as a phantom key.
+    assert edge.label == "hi"
+    assert "label" not in edge.data
 
 
 def test_sync_updates_edge_instance_fields() -> None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -300,11 +300,11 @@ def test_patch_edge_data_updates_edge_instance() -> None:
     )
     flow.patch_edge_data("e1", {"weight": 3, "label": "hi"})
     assert edge.data["weight"] == 3
-    # `label` is a top-level Edge field, not part of `data` (see
-    # panel-multi#60); it should land on `edge.label` and must not leak
-    # into `data` as a phantom key.
+    # `label` is also a top-level Edge field, so it is mirrored onto
+    # `edge.label` (see panel-multi#60) as well as kept in `data`, which keeps
+    # the frontend and Python from disagreeing about where the label lives.
+    assert edge.data["label"] == "hi"
     assert edge.label == "hi"
-    assert "label" not in edge.data
 
 
 def test_sync_updates_edge_instance_fields() -> None:
@@ -445,6 +445,245 @@ def test_parameterized_edge_watchers_clean_up_on_delete() -> None:
     flow.on("edge_data_changed", events.append)
     edge.confidence = 0.2
     assert events == []
+
+
+def _capture_msgs(flow: ReactFlow) -> list:
+    msgs: list = []
+    flow._send_msg = msgs.append
+    return msgs
+
+
+def _two_node_flow(**params) -> ReactFlow:
+    return ReactFlow(
+        nodes=[
+            {"id": "n1", "position": {"x": 0, "y": 0}, "data": {}},
+            {"id": "n2", "position": {"x": 1, "y": 1}, "data": {}},
+        ],
+        **params,
+    )
+
+
+def test_node_base_param_change_patches_props() -> None:
+    node = Node(id="n1", position={"x": 0, "y": 0}, label="A")
+    flow = ReactFlow(nodes=[node])
+    msgs = _capture_msgs(flow)
+    events = []
+    flow.on("node_props_changed", events.append)
+
+    node.label = "A2"
+    node.style = {"backgroundColor": "#ef4444"}
+    node.type = "minimal"
+
+    assert [msg["type"] for msg in msgs] == ["patch_node_props"] * 3
+    assert [msg["patch"] for msg in msgs] == [
+        {"label": "A2"},
+        {"style": {"backgroundColor": "#ef4444"}},
+        {"type": "minimal"},
+    ]
+    assert all(msg["node_id"] == "n1" for msg in msgs)
+    assert [event["patch"] for event in events] == [msg["patch"] for msg in msgs]
+    # The instance stays the source of truth for a full re-serialization.
+    assert node.to_dict()["style"] == {"backgroundColor": "#ef4444"}
+
+
+def test_edge_base_param_change_patches_props() -> None:
+    edge = Edge(id="e1", source="n1", target="n2")
+    flow = _two_node_flow(edges=[edge])
+    msgs = _capture_msgs(flow)
+
+    edge.style = {"strokeWidth": 6, "stroke": "#ef4444"}
+    edge.type = "step"
+    edge.label = "0.75"
+
+    assert [msg["patch"] for msg in msgs] == [
+        {"style": {"strokeWidth": 6, "stroke": "#ef4444"}},
+        {"type": "step"},
+        {"label": "0.75"},
+    ]
+    assert all(msg["type"] == "patch_edge_props" and msg["edge_id"] == "e1" for msg in msgs)
+    # Top-level fields must not leak into the edge's data dictionary.
+    assert edge.data == {}
+
+
+def test_edge_prop_set_to_none_clears_field() -> None:
+    edge = Edge(id="e1", source="n1", target="n2", style={"stroke": "red"})
+    flow = _two_node_flow(edges=[edge])
+    msgs = _capture_msgs(flow)
+
+    edge.style = None
+
+    assert msgs[-1]["patch"] == {"style": None}
+    assert "style" not in edge.to_dict()
+
+
+def test_batched_prop_updates_coalesce_into_one_patch() -> None:
+    node = Node(id="n1", position={"x": 0, "y": 0})
+    flow = ReactFlow(nodes=[node])
+    msgs = _capture_msgs(flow)
+
+    node.param.update(label="renamed", className="highlight")
+
+    assert len(msgs) == 1
+    assert msgs[0]["patch"] == {"label": "renamed", "className": "highlight"}
+
+
+def test_subclass_and_base_params_patch_separately() -> None:
+    node = _ParameterizedNode(id="n1", type="custom", position={"x": 0, "y": 0}, data={})
+    flow = ReactFlow(nodes=[node])
+    msgs = _capture_msgs(flow)
+
+    node.threshold = 0.9
+    node.label = "Threshold node"
+
+    assert msgs[0] == {"type": "patch_node_data", "node_id": "n1", "patch": {"threshold": 0.9}}
+    assert msgs[1] == {"type": "patch_node_props", "node_id": "n1", "patch": {"label": "Threshold node"}}
+    assert node.data == {"threshold": 0.9}
+
+
+def test_patch_node_props_updates_dict_node() -> None:
+    flow = ReactFlow(nodes=[{"id": "n1", "position": {"x": 0, "y": 0}, "data": {}, "style": {"stroke": "red"}}])
+    msgs = _capture_msgs(flow)
+
+    flow.patch_node_props("n1", {"label": "Renamed", "position": {"x": 5, "y": 6}})
+    assert flow.nodes[0]["label"] == "Renamed"
+    assert flow.nodes[0]["position"] == {"x": 5, "y": 6}
+    assert msgs[-1]["patch"] == {"label": "Renamed", "position": {"x": 5, "y": 6}}
+
+    flow.patch_node_props("n1", {"style": None})
+    assert "style" not in flow.nodes[0]
+
+
+def test_patch_edge_props_updates_dict_edge() -> None:
+    flow = _two_node_flow(edges=[{"id": "e1", "source": "n1", "target": "n2", "data": {}}])
+    msgs = _capture_msgs(flow)
+
+    flow.patch_edge_props("e1", {"type": "step"})
+
+    assert flow.edges[0]["type"] == "step"
+    assert flow.edges[0]["data"] == {}
+    assert msgs[-1] == {"type": "patch_edge_props", "edge_id": "e1", "patch": {"type": "step"}}
+
+
+def test_patch_props_on_instance_sends_single_message() -> None:
+    node = Node(id="n1", position={"x": 0, "y": 0})
+    flow = ReactFlow(nodes=[node])
+    msgs = _capture_msgs(flow)
+
+    flow.patch_node_props("n1", {"label": "Renamed"})
+
+    assert node.label == "Renamed"
+    assert len(msgs) == 1
+
+
+def test_patch_props_rejects_data_keys() -> None:
+    flow = _two_node_flow(edges=[{"id": "e1", "source": "n1", "target": "n2", "data": {}}])
+    with pytest.raises(ValueError, match="patch_node_data"):
+        flow.patch_node_props("n1", {"weight": 3})
+    with pytest.raises(ValueError, match="patch_edge_data"):
+        flow.patch_edge_props("e1", {"data": {"weight": 3}})
+
+
+def test_prop_watchers_clean_up_on_delete() -> None:
+    node = Node(id="n1", position={"x": 0, "y": 0})
+    edge = Edge(id="e1", source="n1", target="n2")
+    flow = ReactFlow(nodes=[node, {"id": "n2", "position": {"x": 1, "y": 1}, "data": {}}], edges=[edge])
+    msgs = _capture_msgs(flow)
+
+    flow.remove_edge("e1")
+    flow.remove_node("n1")
+    node.label = "detached"
+    edge.style = {"stroke": "red"}
+
+    assert [msg for msg in msgs if msg["type"].endswith("_props")] == []
+
+
+def test_sync_does_not_echo_prop_patches() -> None:
+    node = Node(id="n1", position={"x": 0, "y": 0}, label="A")
+    edge = Edge(id="e1", source="n1", target="n2")
+    flow = ReactFlow(nodes=[node, {"id": "n2", "position": {"x": 1, "y": 1}, "data": {}}], edges=[edge])
+    msgs = _capture_msgs(flow)
+
+    flow._handle_msg(
+        {
+            "type": "sync",
+            "nodes": [{"id": "n1", "position": {"x": 4, "y": 5}, "label": "B", "data": {}}],
+            "edges": [{"id": "e1", "source": "n1", "target": "n2", "type": "step", "data": {}}],
+        }
+    )
+
+    assert node.label == "B"
+    assert edge.type == "step"
+    assert [msg for msg in msgs if msg["type"].endswith("_props")] == []
+
+
+def test_node_props_change_invokes_hook() -> None:
+    class _HookNode(Node):
+        def __init__(self, **params):
+            super().__init__(**params)
+            self.patches = []
+
+        def on_props_change(self, payload, flow):
+            self.patches.append(payload["patch"])
+
+    node = _HookNode(id="n1", position={"x": 0, "y": 0})
+    flow = ReactFlow(nodes=[node])
+    _capture_msgs(flow)
+
+    node.style = {"opacity": 0.5}
+
+    assert node.patches == [{"style": {"opacity": 0.5}}]
+
+
+def test_patch_edge_data_label_mirrors_onto_prop() -> None:
+    edge = Edge(id="e1", source="n1", target="n2", data={})
+    flow = _two_node_flow(edges=[edge])
+    msgs = _capture_msgs(flow)
+
+    flow.patch_edge_data("e1", {"weight": 0.9, "label": "strong"})
+
+    # The key stays in ``data`` for backwards compatibility, but the parameter
+    # now follows so a full re-serialization keeps the label.
+    assert edge.data == {"weight": 0.9, "label": "strong"}
+    assert edge.label == "strong"
+    assert edge.to_dict()["label"] == "strong"
+    assert [msg["type"] for msg in msgs] == ["patch_edge_data", "patch_edge_props"]
+    assert msgs[0]["patch"] == {"weight": 0.9, "label": "strong"}
+    assert msgs[1]["patch"] == {"label": "strong"}
+
+
+def test_patch_edge_data_label_mirrors_onto_dict_edge() -> None:
+    flow = _two_node_flow(edges=[{"id": "e1", "source": "n1", "target": "n2", "data": {}}])
+    _capture_msgs(flow)
+
+    flow.patch_edge_data("e1", {"label": "strong"})
+
+    assert flow.edges[0]["label"] == "strong"
+
+
+def test_patch_node_data_label_mirrors_onto_prop() -> None:
+    node = Node(id="n1", position={"x": 0, "y": 0}, data={})
+    flow = ReactFlow(nodes=[node])
+    msgs = _capture_msgs(flow)
+
+    # ``_label`` is the key the node components read, so it mirrors too.
+    flow.patch_node_data("n1", {"_label": "Renamed"})
+
+    assert node.label == "Renamed"
+    assert [msg["type"] for msg in msgs] == ["patch_node_data", "patch_node_props"]
+    assert msgs[1]["patch"] == {"label": "Renamed"}
+
+
+def test_patch_data_does_not_mirror_other_props() -> None:
+    edge = Edge(id="e1", source="n1", target="n2", data={})
+    flow = _two_node_flow(edges=[edge])
+    msgs = _capture_msgs(flow)
+
+    flow.patch_edge_data("e1", {"style": {"stroke": "red"}, "type": "domain-type"})
+
+    assert edge.style is None
+    assert edge.type is None
+    assert edge.data == {"style": {"stroke": "red"}, "type": "domain-type"}
+    assert [msg["type"] for msg in msgs] == ["patch_edge_data"]
 
 
 def test_edge_flow_ref_updates_on_edges_assignment() -> None:

--- a/tests/ui/test_ui.py
+++ b/tests/ui/test_ui.py
@@ -1,5 +1,7 @@
 """UI tests for ReactFlow using Playwright."""
 
+import re
+
 import panel as pn
 import panel.models.jsoneditor  # noqa
 import param
@@ -202,44 +204,93 @@ def test_patch_node_and_edge_labels_update_ui(page):
     expect(_edge_label_locator(page, "Edge patched")).to_have_count(1)
 
 
-def test_base_node_edge_params_sync_live_to_ui(page):
+def _instance_flow():
+    nodes = [
+        Node(id="n1", position={"x": 0, "y": 0}, label="Start"),
+        Node(id="n2", position={"x": 260, "y": 60}, label="End"),
+    ]
+    edges = [Edge(id="e1", source="n1", target="n2", label="Edge A")]
+    flow = ReactFlow(nodes=nodes, edges=edges, width=900, height=600)
+    return flow, nodes, edges
+
+
+def _edge_style(page, prop):
+    return page.locator(".react-flow__edge-path").first.evaluate(f"el => getComputedStyle(el).{prop}")
+
+
+def _node_style(page, label, prop):
+    return _node_locator(page, label).first.evaluate(f"el => getComputedStyle(el).{prop}")
+
+
+def test_base_param_assignment_updates_ui(page):
     """Regression test for panel-multi#60.
 
-    Assigning base ``Node``/``Edge`` params (label/style/type) on an
-    existing instance must reach the browser immediately, without needing
-    to reassign ``flow.nodes``/``flow.edges`` as a workaround.
+    Assigning a base ``Node``/``Edge`` param on a live instance must reach the
+    browser immediately, without reassigning ``flow.nodes``/``flow.edges``.
     """
-    node = Node(id="n1", position={"x": 0, "y": 0}, label="Start")
-    edge = Edge(id="e1", source="n1", target="n2")
-    flow = ReactFlow(
-        nodes=[node, Node(id="n2", position={"x": 260, "y": 60}, label="End")],
-        edges=[edge],
-        width=900,
-        height=600,
-    )
+    flow, nodes, edges = _instance_flow()
+    serve_component(page, flow)
+    expect(_node_locator(page, "Start")).to_have_count(1)
+
+    nodes[0].label = "Start patched"
+    edges[0].label = "Edge patched"
+    edges[0].style = {"strokeWidth": 6}
+
+    expect(_node_locator(page, "Start patched")).to_have_count(1)
+    expect(_edge_label_locator(page, "Edge patched")).to_have_count(1)
+    wait_until(lambda: _edge_style(page, "strokeWidth") == "6px", timeout=8000)
+
+
+def test_edge_type_assignment_updates_ui(page):
+    flow, _nodes, edges = _instance_flow()
+    serve_component(page, flow)
+    expect(page.locator(".react-flow__edge")).to_have_count(1)
+
+    edges[0].type = "step"
+
+    expect(page.locator(".react-flow__edge-step")).to_have_count(1)
+
+
+def test_style_assignment_cleared_by_none(page):
+    flow, nodes, edges = _instance_flow()
     serve_component(page, flow)
 
-    edge_path = page.locator('.react-flow__edge[data-id="e1"] path.react-flow__edge-path').first
-    node_label = page.locator('.react-flow__node[data-id="n1"] .rf-node-label')
-    expect(node_label).to_have_text("Start")
+    edges[0].style = {"strokeWidth": 6}
+    wait_until(lambda: _edge_style(page, "strokeWidth") == "6px", timeout=8000)
 
-    initial_stroke = edge_path.evaluate("el => window.getComputedStyle(el).stroke")
+    edges[0].style = None
+    wait_until(lambda: _edge_style(page, "strokeWidth") != "6px", timeout=8000)
 
-    # Direct assignment on the live instances - should be a no-op no longer.
-    node.label = "Start2"
-    edge.style = {"stroke": "#ef4444", "strokeWidth": 6}
+    nodes[0].style = {"opacity": 0.5}
+    wait_until(lambda: _node_style(page, "Start", "opacity") == "0.5", timeout=8000)
 
-    expect(node_label).to_have_text("Start2")
+    nodes[0].style = None
+    wait_until(lambda: _node_style(page, "Start", "opacity") == "1", timeout=8000)
 
-    def _stroke_updated():
-        return edge_path.evaluate("el => window.getComputedStyle(el).stroke") != initial_stroke
 
-    wait_until(_stroke_updated, timeout=8000)
-    assert edge_path.evaluate("el => window.getComputedStyle(el).stroke") == "rgb(239, 68, 68)"
+def test_class_name_assignment_updates_ui(page):
+    flow, nodes, _edges = _instance_flow()
+    serve_component(page, flow)
 
-    # Clearing style (None) should remove it, falling back to the default.
-    edge.style = None
-    wait_until(lambda: edge_path.evaluate("el => window.getComputedStyle(el).stroke") == initial_stroke, timeout=8000)
+    nodes[0].className = "custom-node"
+
+    expect(_node_locator(page, "Start")).to_have_class(re.compile(r"custom-node"))
+
+    # A full re-serialization must not drop the declared class again.
+    flow.nodes = list(flow.nodes)
+    expect(_node_locator(page, "Start")).to_have_class(re.compile(r"custom-node"))
+
+
+def test_patch_props_moves_node(page):
+    flow, _nodes, _edges = _instance_flow()
+    serve_component(page, flow)
+
+    flow.patch_node_props("n1", {"position": {"x": 400, "y": 200}})
+
+    wait_until(
+        lambda: "translate(400px, 200px)" in _node_locator(page, "Start").first.get_attribute("style"),
+        timeout=8000,
+    )
 
 
 def test_programmatic_add_remove_nodes_edges(page):

--- a/tests/ui/test_ui.py
+++ b/tests/ui/test_ui.py
@@ -7,7 +7,7 @@ import pytest
 from panel.custom import Child, ReactComponent
 from panel.tests.util import serve_component, wait_until
 
-from panel_reactflow import EdgeSpec, JsonEditor, Node, NodeSpec, NodeType, ReactFlow
+from panel_reactflow import Edge, EdgeSpec, JsonEditor, Node, NodeSpec, NodeType, ReactFlow
 
 pytest.importorskip("playwright")
 
@@ -200,6 +200,46 @@ def test_patch_node_and_edge_labels_update_ui(page):
 
     expect(_node_locator(page, "Start patched")).to_have_count(1)
     expect(_edge_label_locator(page, "Edge patched")).to_have_count(1)
+
+
+def test_base_node_edge_params_sync_live_to_ui(page):
+    """Regression test for panel-multi#60.
+
+    Assigning base ``Node``/``Edge`` params (label/style/type) on an
+    existing instance must reach the browser immediately, without needing
+    to reassign ``flow.nodes``/``flow.edges`` as a workaround.
+    """
+    node = Node(id="n1", position={"x": 0, "y": 0}, label="Start")
+    edge = Edge(id="e1", source="n1", target="n2")
+    flow = ReactFlow(
+        nodes=[node, Node(id="n2", position={"x": 260, "y": 60}, label="End")],
+        edges=[edge],
+        width=900,
+        height=600,
+    )
+    serve_component(page, flow)
+
+    edge_path = page.locator('.react-flow__edge[data-id="e1"] path.react-flow__edge-path').first
+    node_label = page.locator('.react-flow__node[data-id="n1"] .rf-node-label')
+    expect(node_label).to_have_text("Start")
+
+    initial_stroke = edge_path.evaluate("el => window.getComputedStyle(el).stroke")
+
+    # Direct assignment on the live instances - should be a no-op no longer.
+    node.label = "Start2"
+    edge.style = {"stroke": "#ef4444", "strokeWidth": 6}
+
+    expect(node_label).to_have_text("Start2")
+
+    def _stroke_updated():
+        return edge_path.evaluate("el => window.getComputedStyle(el).stroke") != initial_stroke
+
+    wait_until(_stroke_updated, timeout=8000)
+    assert edge_path.evaluate("el => window.getComputedStyle(el).stroke") == "rgb(239, 68, 68)"
+
+    # Clearing style (None) should remove it, falling back to the default.
+    edge.style = None
+    wait_until(lambda: edge_path.evaluate("el => window.getComputedStyle(el).stroke") == initial_stroke, timeout=8000)
 
 
 def test_programmatic_add_remove_nodes_edges(page):


### PR DESCRIPTION

<!-- Using AI? READ FIRST: https://holoviz.org/contribute.html#ai-readme -->

## Description
<!-- Summarize the change and which issue is fixed. Be sure to include relevant motivation and context. Describe the tests run to verify these changes and how to reproduce them (copy-pastable minimal, reproducible example). Include visuals when possible (e.g. before/after screenshots). -->

Assigning label, style, type, className, markerEnd, sourceHandle, or targetHandle on a live Node/Edge instance was a silent no-op: only subclass-defined data params were watched and pushed to the frontend, so base params only reached the DOM after a full flow.nodes/flow.edges reassignment.

- Node/Edge now declare _TOP_LEVEL_SYNC_PARAMS, the base params that map to top-level React Flow fields rather than arbitrary data keys.
- Param watcher setup/teardown for nodes and edges is unified into one generic _update_param_watchers/_on_synced_param_change pair instead of four near-duplicate methods.
- patch_node_data/patch_edge_data split a patch into top-level vs data keys via a shared _apply_data_patch helper, and send that same split ("patch" + "top_patch") to the frontend so reactflow.jsx doesn't need its own copy of which keys are top-level to stay in sync.
- Also fixes a side effect where patch_edge_data(..., {"label": ...}) left a phantom "label" key in edge.data instead of updating edge.label.

Adds a UI regression test asserting direct attribute assignment updates the DOM immediately, including that style=None clears back to default.



## AI Disclosure
<!-- Delete this section if AI was not used, else specify the tool/model (e.g. Cursor + Sonnet 4.6, Claude Code + Opus 4.6, ChatGPT) and briefly describe how it was used. Failure to disclose AI usage may result in a ban. -->

Tool & Model: Kilo:anthropic/claude-sonnet-5
Usage:

- [ ] I have tested all AI-generated content in my PR.
- [ ] I take responsibility for all AI-generated content in my PR.


## Checklist
<!-- Remove the non relevant items. -->

- [x] Tests added and are passing
- [x] Added documentation
