### PR TITLE
Fix/batch node removal

### DIFF
--- a/docs/how-to/define-nodes-edges.md
+++ b/docs/how-to/define-nodes-edges.md
@@ -419,14 +419,14 @@ flow.remove_node("n3")   # also removes connected edges
 flow.remove_edge("e1")
 ```
 
-To remove several elements at once, use `remove_nodes()` and `remove_edges()`
-rather than looping over the singular methods. The plural forms assign `nodes`
-and `edges` once, so the browser renders a single update instead of one per
-element:
+`remove_node()` and `remove_edge()` also take several ids at once, either as
+separate arguments or as a single sequence. Pass them together rather than
+calling the methods in a loop: a batch assigns `nodes` and `edges` once, so the
+browser renders a single update instead of one per element.
 
 ```python
-flow.remove_nodes(["n1", "n2", "n3"])   # also removes connected edges
-flow.remove_edges(["e1", "e2"])
+flow.remove_node("n1", "n2", "n3")   # also removes connected edges
+flow.remove_edge(["e1", "e2"])
 ```
 
 More generally, every parameter assignment is synced to the browser on its own

--- a/docs/how-to/define-nodes-edges.md
+++ b/docs/how-to/define-nodes-edges.md
@@ -418,3 +418,26 @@ flow.add_edge(EdgeSpec(id="e2", source="n3", target="n4"))
 flow.remove_node("n3")   # also removes connected edges
 flow.remove_edge("e1")
 ```
+
+To remove several elements at once, use `remove_nodes()` and `remove_edges()`
+rather than looping over the singular methods. The plural forms assign `nodes`
+and `edges` once, so the browser renders a single update instead of one per
+element:
+
+```python
+flow.remove_nodes(["n1", "n2", "n3"])   # also removes connected edges
+flow.remove_edges(["e1", "e2"])
+```
+
+More generally, every parameter assignment is synced to the browser on its own
+and the canvas re-renders per sync, so a sequence of updates renders each
+intermediate graph. Wrap any batch of changes in `pn.io.hold()` to combine them
+into a single render:
+
+```python
+import panel as pn
+
+with pn.io.hold():
+    flow.nodes = new_nodes
+    flow.edges = new_edges
+```

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,5 +1,23 @@
 # Release Notes
 
+## Unreleased
+
+### Bug fixes
+
+- **Progressive re-render when deleting multiple elements** — deleting a
+  multi-node selection removed the nodes one at a time, syncing an
+  intermediate graph to the browser per node so the nodes visibly
+  disappeared one by one. Updates triggered by a frontend message are now
+  held and combined into a single patch, and node/edge deletion assigns
+  `nodes` and `edges` once.
+
+### Enhancements
+
+- **`remove_nodes()` / `remove_edges()`** — new methods that remove
+  several elements in a single update, for use instead of looping over
+  `remove_node()` / `remove_edge()`. For any other batch of changes made
+  from Python, wrap them in `pn.io.hold()` to render them at once.
+
 ## Version 0.4.1
 
 A small enhancement release adding viewport zoom controls.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -13,10 +13,12 @@
 
 ### Enhancements
 
-- **`remove_nodes()` / `remove_edges()`** — new methods that remove
-  several elements in a single update, for use instead of looping over
-  `remove_node()` / `remove_edge()`. For any other batch of changes made
-  from Python, wrap them in `pn.io.hold()` to render them at once.
+- **Batch removal** — `remove_node()` and `remove_edge()` now accept
+  several ids, either as separate arguments
+  (`flow.remove_node("n1", "n2")`) or as a sequence
+  (`flow.remove_node(["n1", "n2"])`), and remove them in a single update.
+  For any other batch of changes made from Python, wrap them in
+  `pn.io.hold()` to render them at once.
 
 ## Version 0.4.1
 

--- a/src/panel_reactflow/base.py
+++ b/src/panel_reactflow/base.py
@@ -54,6 +54,17 @@ BK_FIGURE_CSS = """
 """
 
 
+def _flatten_ids(ids: Sequence[str | Sequence[str]]) -> list[str]:
+    """Flatten mixed id arguments, i.e. bare ids and sequences of ids."""
+    flat: list[str] = []
+    for id_or_ids in ids:
+        if isinstance(id_or_ids, str):
+            flat.append(id_or_ids)
+        else:
+            flat.extend(id_or_ids)
+    return flat
+
+
 def _ensure_jsonable(value: Any, path: str) -> None:
     """Ensure value can be JSON-serialized for syncing to the frontend."""
 
@@ -2448,12 +2459,12 @@ class ReactFlow(ReactComponent):
                 node_ids = list(msg.get("node_ids") or [])
                 if msg.get("node_id") and msg["node_id"] not in node_ids:
                     node_ids.append(msg["node_id"])
-                self.remove_nodes(node_ids)
+                self.remove_node(node_ids)
             case "edge_deleted":
                 edge_ids = list(msg.get("edge_ids") or [])
                 if msg.get("edge_id") and msg["edge_id"] not in edge_ids:
                     edge_ids.append(msg["edge_id"])
-                self.remove_edges(edge_ids)
+                self.remove_edge(edge_ids)
             case "node_clicked":
                 node_id = msg.get("node_id")
                 if node_id is None:
@@ -2509,17 +2520,25 @@ class ReactFlow(ReactComponent):
             )
         self._emit("client_error", msg)
 
-    def remove_node(self, node_id: str) -> None:
-        """Remove a node and all connected edges from the graph.
+    def remove_node(self, *node_ids: str | Sequence[str]) -> None:
+        """Remove one or more nodes and all connected edges from the graph.
 
-        Removes the specified node and automatically removes any edges that
-        are connected to it (either as source or target). This ensures the
+        Removes the specified nodes and automatically removes any edges that
+        are connected to them (either as source or target). This ensures the
         graph remains consistent.
+
+        Ids may be passed as separate arguments or as a single sequence. All
+        of them are removed in one update, i.e. ``nodes`` and ``edges`` are
+        each assigned once. Removing nodes one at a time instead syncs an
+        intermediate graph to the browser per node, which React Flow renders
+        as the nodes disappearing one by one.
 
         Parameters
         ----------
-        node_id : str
-            Unique identifier of the node to remove.
+        *node_ids : str or sequence of str
+            Unique identifiers of the nodes to remove, either as separate
+            arguments or as a single sequence. Ids that are not part of the
+            graph are ignored.
 
         Examples
         --------
@@ -2532,40 +2551,17 @@ class ReactFlow(ReactComponent):
         >>>
         >>> flow.remove_node("n1")  # Also removes edge "e1"
 
+        Remove several nodes in a single update:
+
+        >>> flow.remove_node("n1", "n2")
+        >>> flow.remove_node(["n1", "n2"])
+
         See Also
         --------
         add_node : Add a node to the graph
-        remove_nodes : Remove several nodes in a single update
-        remove_edge : Remove an edge from the graph
+        remove_edge : Remove one or more edges from the graph
         """
-        self.remove_nodes([node_id])
-
-    def remove_nodes(self, node_ids: Sequence[str]) -> None:
-        """Remove multiple nodes and their connected edges in one update.
-
-        Equivalent to calling :meth:`remove_node` for each id, but the
-        ``nodes`` and ``edges`` parameters are only assigned once. Removing
-        nodes one at a time syncs an intermediate graph to the browser per
-        node, which React Flow renders as the nodes disappearing one by one.
-
-        Parameters
-        ----------
-        node_ids : sequence of str
-            Unique identifiers of the nodes to remove. Ids that are not part
-            of the graph are ignored.
-
-        Examples
-        --------
-        Remove several nodes at once:
-
-        >>> flow.remove_nodes(["n1", "n2"])
-
-        See Also
-        --------
-        remove_node : Remove a single node
-        remove_edges : Remove several edges in a single update
-        """
-        ids = list(dict.fromkeys(node_ids))
+        ids = list(dict.fromkeys(_flatten_ids(node_ids)))
         if not ids:
             return
         id_set = set(ids)
@@ -2703,13 +2699,19 @@ class ReactFlow(ReactComponent):
         self.edges = self.edges + [raw_edge if isinstance(raw_edge, Edge) else payload]
         self._emit("edge_added", {"type": "edge_added", "edge": payload})
 
-    def remove_edge(self, edge_id: str) -> None:
-        """Remove an edge from the graph by its ID.
+    def remove_edge(self, *edge_ids: str | Sequence[str]) -> None:
+        """Remove one or more edges from the graph by their ID.
+
+        Ids may be passed as separate arguments or as a single sequence. All
+        of them are removed in one update, i.e. ``edges`` is only assigned
+        once, so the browser renders a single update instead of one per edge.
 
         Parameters
         ----------
-        edge_id : str
-            Unique identifier of the edge to remove.
+        *edge_ids : str or sequence of str
+            Unique identifiers of the edges to remove, either as separate
+            arguments or as a single sequence. Ids that are not part of the
+            graph are ignored.
 
         Examples
         --------
@@ -2719,39 +2721,17 @@ class ReactFlow(ReactComponent):
         >>> flow.add_edge(EdgeSpec(id="e1", source="n1", target="n2"))
         >>> flow.remove_edge("e1")
 
+        Remove several edges in a single update:
+
+        >>> flow.remove_edge("e1", "e2")
+        >>> flow.remove_edge(["e1", "e2"])
+
         See Also
         --------
         add_edge : Add an edge to the graph
-        remove_edges : Remove several edges in a single update
-        remove_node : Remove a node from the graph
+        remove_node : Remove one or more nodes from the graph
         """
-        self.remove_edges([edge_id])
-
-    def remove_edges(self, edge_ids: Sequence[str]) -> None:
-        """Remove multiple edges from the graph in one update.
-
-        Equivalent to calling :meth:`remove_edge` for each id, but the
-        ``edges`` parameter is only assigned once so the browser renders a
-        single update instead of one per edge.
-
-        Parameters
-        ----------
-        edge_ids : sequence of str
-            Unique identifiers of the edges to remove. Ids that are not part
-            of the graph are ignored.
-
-        Examples
-        --------
-        Remove several edges at once:
-
-        >>> flow.remove_edges(["e1", "e2"])
-
-        See Also
-        --------
-        remove_edge : Remove a single edge
-        remove_nodes : Remove several nodes in a single update
-        """
-        ids = list(dict.fromkeys(edge_ids))
+        ids = list(dict.fromkeys(_flatten_ids(edge_ids)))
         if not ids:
             return
         id_set = set(ids)

--- a/src/panel_reactflow/base.py
+++ b/src/panel_reactflow/base.py
@@ -7,7 +7,7 @@ import inspect
 import json
 import logging
 import os
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass
 from functools import partial
@@ -21,6 +21,7 @@ from bokeh.embed.bundle import extension_dirs
 from bokeh.plotting import figure
 from panel.config import config
 from panel.custom import Child, Children, ReactComponent
+from panel.io.document import hold
 from panel.io.resources import EXTENSION_CDN
 from panel.io.state import state
 from panel.util import base_version, classproperty
@@ -2399,9 +2400,19 @@ class ReactFlow(ReactComponent):
             self.edges = synced_edges
 
     def _handle_msg(self, msg: dict[str, Any]) -> None:
-        """Handle sync messages from the frontend."""
+        """Handle sync messages from the frontend.
+
+        Held so that every parameter update triggered by one frontend message
+        is combined into a single patch. Without the hold each assignment syncs
+        on its own and the browser renders every intermediate graph, e.g.
+        deleting a multi-node selection shows the nodes disappearing one by one.
+        """
         if not isinstance(msg, dict):
             return
+        with hold():
+            self._process_msg(msg)
+
+    def _process_msg(self, msg: dict[str, Any]) -> None:
         match msg.get("type"):
             case "sync":
                 nodes = msg.get("nodes")
@@ -2434,17 +2445,15 @@ class ReactFlow(ReactComponent):
                     return
                 self.add_edge(edge)
             case "node_deleted":
-                node_ids = msg.get("node_ids") or []
-                if msg.get("node_id"):
-                    node_ids = list(set(node_ids) | {msg.get("node_id")})
-                for node_id in node_ids:
-                    self.remove_node(node_id)
+                node_ids = list(msg.get("node_ids") or [])
+                if msg.get("node_id") and msg["node_id"] not in node_ids:
+                    node_ids.append(msg["node_id"])
+                self.remove_nodes(node_ids)
             case "edge_deleted":
-                edge_ids = msg.get("edge_ids") or []
-                if msg.get("edge_id"):
-                    edge_ids = list(set(edge_ids) | {msg.get("edge_id")})
-                for edge_id in edge_ids:
-                    self.remove_edge(edge_id)
+                edge_ids = list(msg.get("edge_ids") or [])
+                if msg.get("edge_id") and msg["edge_id"] not in edge_ids:
+                    edge_ids.append(msg["edge_id"])
+                self.remove_edges(edge_ids)
             case "node_clicked":
                 node_id = msg.get("node_id")
                 if node_id is None:
@@ -2526,37 +2535,85 @@ class ReactFlow(ReactComponent):
         See Also
         --------
         add_node : Add a node to the graph
+        remove_nodes : Remove several nodes in a single update
         remove_edge : Remove an edge from the graph
         """
-        removed_node = next((node for node in self.nodes if self._node_id(node) == node_id), None)
-        nodes = [node for node in self.nodes if self._node_id(node) != node_id]
-        removed_edges = [
-            edge
-            for edge in self.edges
-            if (edge.source if isinstance(edge, Edge) else edge.get("source")) == node_id
-            or (edge.target if isinstance(edge, Edge) else edge.get("target")) == node_id
-        ]
-        self.nodes = nodes
+        self.remove_nodes([node_id])
+
+    def remove_nodes(self, node_ids: Sequence[str]) -> None:
+        """Remove multiple nodes and their connected edges in one update.
+
+        Equivalent to calling :meth:`remove_node` for each id, but the
+        ``nodes`` and ``edges`` parameters are only assigned once. Removing
+        nodes one at a time syncs an intermediate graph to the browser per
+        node, which React Flow renders as the nodes disappearing one by one.
+
+        Parameters
+        ----------
+        node_ids : sequence of str
+            Unique identifiers of the nodes to remove. Ids that are not part
+            of the graph are ignored.
+
+        Examples
+        --------
+        Remove several nodes at once:
+
+        >>> flow.remove_nodes(["n1", "n2"])
+
+        See Also
+        --------
+        remove_node : Remove a single node
+        remove_edges : Remove several edges in a single update
+        """
+        ids = list(dict.fromkeys(node_ids))
+        if not ids:
+            return
+        id_set = set(ids)
+        removed_nodes = {}
+        remaining_nodes = []
+        for node in self.nodes:
+            node_id = self._node_id(node)
+            if node_id in id_set:
+                removed_nodes.setdefault(node_id, node)
+            else:
+                remaining_nodes.append(node)
+        removed_edges = [edge for edge in self.edges if self._edge_endpoints(edge) & id_set]
+        updates: dict[str, Any] = {}
+        if removed_nodes:
+            updates["nodes"] = remaining_nodes
         if removed_edges:
-            remaining_edges = [edge for edge in self.edges if edge not in removed_edges]
-            self.edges = remaining_edges
-        self._emit(
-            "node_deleted",
-            {
-                "type": "node_deleted",
-                "node_id": node_id,
-                "deleted_edges": [self._edge_id(edge) for edge in removed_edges],
-            },
-        )
-        if isinstance(removed_node, Node):
-            removed_node.flow = None
+            updates["edges"] = [edge for edge in self.edges if edge not in removed_edges]
+        if updates:
+            self.param.update(**updates)
+        # Report each edge under the first node that removed it, matching the
+        # payloads emitted when removing the nodes sequentially.
+        reported_edges: set[str | None] = set()
+        for node_id in ids:
+            deleted_edges = []
+            for edge in removed_edges:
+                edge_id = self._edge_id(edge)
+                if edge_id in reported_edges or node_id not in self._edge_endpoints(edge):
+                    continue
+                reported_edges.add(edge_id)
+                deleted_edges.append(edge_id)
             payload = {
                 "type": "node_deleted",
                 "node_id": node_id,
-                "deleted_edges": [self._edge_id(edge) for edge in removed_edges],
+                "deleted_edges": deleted_edges,
             }
-            self._invoke_node_hook(removed_node, "on_delete", payload)
-            self._invoke_node_hook(removed_node, "on_event", payload)
+            self._emit("node_deleted", payload)
+            removed_node = removed_nodes.get(node_id)
+            if isinstance(removed_node, Node):
+                removed_node.flow = None
+                self._invoke_node_hook(removed_node, "on_delete", dict(payload))
+                self._invoke_node_hook(removed_node, "on_event", dict(payload))
+
+    @classmethod
+    def _edge_endpoints(cls, edge: dict[str, Any] | Edge) -> set[str | None]:
+        """Return the source and target node ids of *edge*."""
+        if isinstance(edge, Edge):
+            return {edge.source, edge.target}
+        return {edge.get("source"), edge.get("target")}
 
     def add_edge(self, edge: dict[str, Any] | EdgeSpec | Edge) -> None:
         """Add an edge to the graph.
@@ -2665,18 +2722,59 @@ class ReactFlow(ReactComponent):
         See Also
         --------
         add_edge : Add an edge to the graph
+        remove_edges : Remove several edges in a single update
         remove_node : Remove a node from the graph
         """
-        removed_edge = next((edge for edge in self.edges if self._edge_id(edge) == edge_id), None)
-        removed = [edge for edge in self.edges if self._edge_id(edge) == edge_id]
-        self.edges = [edge for edge in self.edges if self._edge_id(edge) != edge_id]
-        if removed:
-            self._emit("edge_deleted", {"type": "edge_deleted", "edge_id": edge_id})
-        if isinstance(removed_edge, Edge):
-            removed_edge.flow = None
+        self.remove_edges([edge_id])
+
+    def remove_edges(self, edge_ids: Sequence[str]) -> None:
+        """Remove multiple edges from the graph in one update.
+
+        Equivalent to calling :meth:`remove_edge` for each id, but the
+        ``edges`` parameter is only assigned once so the browser renders a
+        single update instead of one per edge.
+
+        Parameters
+        ----------
+        edge_ids : sequence of str
+            Unique identifiers of the edges to remove. Ids that are not part
+            of the graph are ignored.
+
+        Examples
+        --------
+        Remove several edges at once:
+
+        >>> flow.remove_edges(["e1", "e2"])
+
+        See Also
+        --------
+        remove_edge : Remove a single edge
+        remove_nodes : Remove several nodes in a single update
+        """
+        ids = list(dict.fromkeys(edge_ids))
+        if not ids:
+            return
+        id_set = set(ids)
+        removed_edges = {}
+        remaining_edges = []
+        for edge in self.edges:
+            edge_id = self._edge_id(edge)
+            if edge_id in id_set:
+                removed_edges.setdefault(edge_id, edge)
+            else:
+                remaining_edges.append(edge)
+        if removed_edges:
+            self.edges = remaining_edges
+        for edge_id in ids:
+            removed_edge = removed_edges.get(edge_id)
+            if removed_edge is None:
+                continue
             payload = {"type": "edge_deleted", "edge_id": edge_id}
-            self._invoke_edge_hook(removed_edge, "on_delete", payload)
-            self._invoke_edge_hook(removed_edge, "on_event", payload)
+            self._emit("edge_deleted", payload)
+            if isinstance(removed_edge, Edge):
+                removed_edge.flow = None
+                self._invoke_edge_hook(removed_edge, "on_delete", dict(payload))
+                self._invoke_edge_hook(removed_edge, "on_event", dict(payload))
 
     def _apply_data_patch(
         self,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1315,3 +1315,245 @@ def test_remove_node_with_edge_instances() -> None:
     assert all(n.id != "a" for n in flow.nodes)
     assert len(flow.edges) == 1
     assert flow.edges[0].id == "e2"
+
+
+def _count_sync_messages(flow: ReactFlow, params: list[str]) -> list[list[tuple[str, int]]]:
+    """Record the sync messages Panel would push to the frontend.
+
+    Panel links all parameters through a single ``onlychanged=False`` watcher,
+    so one watcher call corresponds to one message (and one browser render).
+    """
+    messages: list[list[tuple[str, int]]] = []
+    flow.param.watch(
+        lambda *events: messages.append([(e.name, len(e.new)) for e in events]),
+        params,
+        onlychanged=False,
+    )
+    return messages
+
+
+def _chain_flow(n: int = 5) -> ReactFlow:
+    return ReactFlow(
+        nodes=[{"id": f"n{i}", "position": {"x": 100 * i, "y": 0}, "data": {}} for i in range(n)],
+        edges=[{"id": f"e{i}", "source": f"n{i}", "target": f"n{i + 1}", "data": {}} for i in range(n - 1)],
+    )
+
+
+def test_remove_nodes_syncs_once() -> None:
+    """Deleting several nodes must not sync an intermediate graph per node.
+
+    Otherwise the browser renders the removal progressively, one node at a time.
+    """
+    flow = _chain_flow()
+    messages = _count_sync_messages(flow, ["nodes", "edges"])
+    flow.remove_nodes(["n1", "n2", "n3"])
+    assert len(messages) == 1
+    assert [n["id"] for n in flow.nodes] == ["n0", "n4"]
+    assert flow.edges == []
+
+
+def test_handle_msg_node_deleted_syncs_once() -> None:
+    flow = _chain_flow()
+    messages = _count_sync_messages(flow, ["nodes", "edges"])
+    flow._handle_msg({"type": "node_deleted", "node_id": None, "node_ids": ["n1", "n2", "n3"]})
+    assert len(messages) == 1
+    assert [n["id"] for n in flow.nodes] == ["n0", "n4"]
+
+
+def test_handle_msg_edge_deleted_syncs_once() -> None:
+    flow = _chain_flow()
+    messages = _count_sync_messages(flow, ["edges"])
+    flow._handle_msg({"type": "edge_deleted", "edge_id": None, "edge_ids": ["e0", "e1", "e2"]})
+    assert len(messages) == 1
+    assert [e["id"] for e in flow.edges] == ["e3"]
+
+
+def test_remove_node_syncs_nodes_and_edges_together() -> None:
+    flow = _chain_flow()
+    messages = _count_sync_messages(flow, ["nodes", "edges"])
+    flow.remove_node("n1")
+    assert len(messages) == 1
+    assert {name for name, _ in messages[0]} == {"nodes", "edges"}
+
+
+def test_remove_nodes_triggers_views_once() -> None:
+    flow = _chain_flow()
+    triggers = []
+    flow.param.watch(lambda e: triggers.append(e), ["_views"], onlychanged=False)
+    flow.remove_nodes(["n1", "n2", "n3"])
+    assert len(triggers) == 1
+
+
+def test_remove_nodes_matches_sequential_events() -> None:
+    """Batched removal must emit the same events as removing one at a time."""
+    sequential: list[dict] = []
+    flow = _chain_flow()
+    flow.on("node_deleted", sequential.append)
+    for node_id in ["n1", "n2", "n3"]:
+        flow.remove_node(node_id)
+
+    batched: list[dict] = []
+    flow = _chain_flow()
+    flow.on("node_deleted", batched.append)
+    flow.remove_nodes(["n1", "n2", "n3"])
+
+    assert batched == sequential
+
+
+def test_remove_nodes_emits_deletion_events_in_order() -> None:
+    flow = _chain_flow()
+    events: list[dict] = []
+    flow.on("node_deleted", events.append)
+    flow.remove_nodes(["n3", "n1"])
+    assert [e["node_id"] for e in events] == ["n3", "n1"]
+
+
+def test_remove_nodes_ignores_unknown_and_duplicate_ids() -> None:
+    flow = _chain_flow()
+    messages = _count_sync_messages(flow, ["nodes", "edges"])
+    flow.remove_nodes(["n1", "n1", "nope"])
+    assert len(messages) == 1
+    assert [n["id"] for n in flow.nodes] == ["n0", "n2", "n3", "n4"]
+
+    messages.clear()
+    flow.remove_nodes([])
+    flow.remove_nodes(["nope"])
+    assert messages == []
+
+
+def test_remove_edges_ignores_unknown_ids() -> None:
+    flow = _chain_flow()
+    messages = _count_sync_messages(flow, ["edges"])
+    flow.remove_edges(["e0", "e0", "nope"])
+    assert len(messages) == 1
+    assert [e["id"] for e in flow.edges] == ["e1", "e2", "e3"]
+
+    messages.clear()
+    flow.remove_edges(["nope"])
+    assert messages == []
+
+
+def test_remove_nodes_detaches_node_instances() -> None:
+    nodes = [Node(id=f"n{i}", position={"x": 100 * i, "y": 0}) for i in range(3)]
+    edges = [Edge(id="e0", source="n0", target="n1"), Edge(id="e1", source="n1", target="n2")]
+    flow = ReactFlow(nodes=nodes, edges=edges)
+    messages = _count_sync_messages(flow, ["nodes", "edges"])
+    flow.remove_nodes(["n0", "n1"])
+    assert len(messages) == 1
+    assert [n.id for n in flow.nodes] == ["n2"]
+    assert flow.edges == []
+    assert nodes[0].flow is None
+    assert nodes[1].flow is None
+    assert nodes[2].flow is flow
+
+
+def test_remove_edges_detaches_edge_instances() -> None:
+    nodes = [Node(id=f"n{i}", position={"x": 100 * i, "y": 0}) for i in range(3)]
+    edges = [Edge(id="e0", source="n0", target="n1"), Edge(id="e1", source="n1", target="n2")]
+    flow = ReactFlow(nodes=nodes, edges=edges)
+    flow.remove_edges(["e0", "e1"])
+    assert flow.edges == []
+    assert edges[0].flow is None
+    assert edges[1].flow is None
+
+
+def test_hold_combines_loop_removal_into_one_patch(document) -> None:
+    """``pn.io.hold`` is the supported way to batch a sequence of updates.
+
+    Bokeh's ``combine`` hold policy replaces an earlier event for the same
+    property, so repeated ``nodes`` assignments collapse into a single patch
+    and the browser renders the removal once instead of once per node.
+    """
+    from panel.io import hold
+    from panel.io.state import set_curdoc
+
+    flow = _chain_flow()
+    flow.get_root(document)
+    with set_curdoc(document):
+        assert document.callbacks.hold_value is None
+        with hold():
+            assert document.callbacks.hold_value == "combine"
+            for node_id in ["n1", "n2", "n3"]:
+                flow.remove_node(node_id)
+        assert document.callbacks.hold_value is None
+    assert [n["id"] for n in flow.nodes] == ["n0", "n4"]
+    assert flow.edges == []
+
+
+def test_handle_msg_is_held(document) -> None:
+    """Frontend-initiated updates are batched without the caller opting in."""
+    from panel.io.state import set_curdoc
+
+    flow = _chain_flow()
+    flow.get_root(document)
+    holds = []
+    original = flow._process_msg
+
+    def record(msg):
+        holds.append(document.callbacks.hold_value)
+        return original(msg)
+
+    flow._process_msg = record
+    with set_curdoc(document):
+        flow._handle_msg({"type": "node_deleted", "node_id": None, "node_ids": ["n1", "n2"]})
+    assert holds == ["combine"]
+    assert [n["id"] for n in flow.nodes] == ["n0", "n3", "n4"]
+
+
+def test_handle_msg_without_document_still_applies() -> None:
+    flow = _chain_flow()
+    flow._handle_msg({"type": "node_deleted", "node_id": None, "node_ids": ["n1", "n2"]})
+    assert [n["id"] for n in flow.nodes] == ["n0", "n3", "n4"]
+
+
+def test_handle_msg_releases_hold_on_error(document) -> None:
+    from panel.io.state import set_curdoc
+
+    flow = _chain_flow()
+    flow.get_root(document)
+
+    def boom(msg):
+        flow.remove_node("n1")
+        raise RuntimeError("boom")
+
+    flow._process_msg = boom
+    with set_curdoc(document):
+        try:
+            flow._handle_msg({"type": "node_deleted", "node_ids": ["n1"]})
+        except RuntimeError:
+            pass
+        assert document.callbacks.hold_value is None
+
+
+def test_remove_nodes_removes_every_node_matching_an_id() -> None:
+    """A duplicated id must not leave a stale copy behind."""
+    flow = ReactFlow(
+        nodes=[
+            {"id": "n1", "position": {"x": 0, "y": 0}, "data": {}},
+            {"id": "n1", "position": {"x": 10, "y": 10}, "data": {}},
+            {"id": "n2", "position": {"x": 20, "y": 20}, "data": {}},
+        ],
+        edges=[
+            {"id": "e1", "source": "n1", "target": "n2", "data": {}},
+            {"id": "e1", "source": "n2", "target": "n1", "data": {}},
+        ],
+    )
+    flow.remove_nodes(["n1"])
+    assert [n["id"] for n in flow.nodes] == ["n2"]
+    assert flow.edges == []
+
+
+def test_remove_edges_removes_every_edge_matching_an_id() -> None:
+    flow = ReactFlow(
+        nodes=[
+            {"id": "n1", "position": {"x": 0, "y": 0}, "data": {}},
+            {"id": "n2", "position": {"x": 20, "y": 20}, "data": {}},
+        ],
+        edges=[
+            {"id": "e1", "source": "n1", "target": "n2", "data": {}},
+            {"id": "e1", "source": "n2", "target": "n1", "data": {}},
+            {"id": "e2", "source": "n1", "target": "n2", "data": {}},
+        ],
+    )
+    flow.remove_edges(["e1"])
+    assert [e["id"] for e in flow.edges] == ["e2"]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1339,14 +1339,14 @@ def _chain_flow(n: int = 5) -> ReactFlow:
     )
 
 
-def test_remove_nodes_syncs_once() -> None:
+def test_remove_node_batch_syncs_once() -> None:
     """Deleting several nodes must not sync an intermediate graph per node.
 
     Otherwise the browser renders the removal progressively, one node at a time.
     """
     flow = _chain_flow()
     messages = _count_sync_messages(flow, ["nodes", "edges"])
-    flow.remove_nodes(["n1", "n2", "n3"])
+    flow.remove_node(["n1", "n2", "n3"])
     assert len(messages) == 1
     assert [n["id"] for n in flow.nodes] == ["n0", "n4"]
     assert flow.edges == []
@@ -1376,15 +1376,15 @@ def test_remove_node_syncs_nodes_and_edges_together() -> None:
     assert {name for name, _ in messages[0]} == {"nodes", "edges"}
 
 
-def test_remove_nodes_triggers_views_once() -> None:
+def test_remove_node_batch_triggers_views_once() -> None:
     flow = _chain_flow()
     triggers = []
     flow.param.watch(lambda e: triggers.append(e), ["_views"], onlychanged=False)
-    flow.remove_nodes(["n1", "n2", "n3"])
+    flow.remove_node(["n1", "n2", "n3"])
     assert len(triggers) == 1
 
 
-def test_remove_nodes_matches_sequential_events() -> None:
+def test_remove_node_batch_matches_sequential_events() -> None:
     """Batched removal must emit the same events as removing one at a time."""
     sequential: list[dict] = []
     flow = _chain_flow()
@@ -1395,50 +1395,50 @@ def test_remove_nodes_matches_sequential_events() -> None:
     batched: list[dict] = []
     flow = _chain_flow()
     flow.on("node_deleted", batched.append)
-    flow.remove_nodes(["n1", "n2", "n3"])
+    flow.remove_node(["n1", "n2", "n3"])
 
     assert batched == sequential
 
 
-def test_remove_nodes_emits_deletion_events_in_order() -> None:
+def test_remove_node_batch_emits_deletion_events_in_order() -> None:
     flow = _chain_flow()
     events: list[dict] = []
     flow.on("node_deleted", events.append)
-    flow.remove_nodes(["n3", "n1"])
+    flow.remove_node(["n3", "n1"])
     assert [e["node_id"] for e in events] == ["n3", "n1"]
 
 
-def test_remove_nodes_ignores_unknown_and_duplicate_ids() -> None:
+def test_remove_node_batch_ignores_unknown_and_duplicate_ids() -> None:
     flow = _chain_flow()
     messages = _count_sync_messages(flow, ["nodes", "edges"])
-    flow.remove_nodes(["n1", "n1", "nope"])
+    flow.remove_node(["n1", "n1", "nope"])
     assert len(messages) == 1
     assert [n["id"] for n in flow.nodes] == ["n0", "n2", "n3", "n4"]
 
     messages.clear()
-    flow.remove_nodes([])
-    flow.remove_nodes(["nope"])
+    flow.remove_node([])
+    flow.remove_node(["nope"])
     assert messages == []
 
 
-def test_remove_edges_ignores_unknown_ids() -> None:
+def test_remove_edge_batch_ignores_unknown_ids() -> None:
     flow = _chain_flow()
     messages = _count_sync_messages(flow, ["edges"])
-    flow.remove_edges(["e0", "e0", "nope"])
+    flow.remove_edge(["e0", "e0", "nope"])
     assert len(messages) == 1
     assert [e["id"] for e in flow.edges] == ["e1", "e2", "e3"]
 
     messages.clear()
-    flow.remove_edges(["nope"])
+    flow.remove_edge(["nope"])
     assert messages == []
 
 
-def test_remove_nodes_detaches_node_instances() -> None:
+def test_remove_node_batch_detaches_node_instances() -> None:
     nodes = [Node(id=f"n{i}", position={"x": 100 * i, "y": 0}) for i in range(3)]
     edges = [Edge(id="e0", source="n0", target="n1"), Edge(id="e1", source="n1", target="n2")]
     flow = ReactFlow(nodes=nodes, edges=edges)
     messages = _count_sync_messages(flow, ["nodes", "edges"])
-    flow.remove_nodes(["n0", "n1"])
+    flow.remove_node(["n0", "n1"])
     assert len(messages) == 1
     assert [n.id for n in flow.nodes] == ["n2"]
     assert flow.edges == []
@@ -1447,11 +1447,11 @@ def test_remove_nodes_detaches_node_instances() -> None:
     assert nodes[2].flow is flow
 
 
-def test_remove_edges_detaches_edge_instances() -> None:
+def test_remove_edge_batch_detaches_edge_instances() -> None:
     nodes = [Node(id=f"n{i}", position={"x": 100 * i, "y": 0}) for i in range(3)]
     edges = [Edge(id="e0", source="n0", target="n1"), Edge(id="e1", source="n1", target="n2")]
     flow = ReactFlow(nodes=nodes, edges=edges)
-    flow.remove_edges(["e0", "e1"])
+    flow.remove_edge(["e0", "e1"])
     assert flow.edges == []
     assert edges[0].flow is None
     assert edges[1].flow is None
@@ -1525,7 +1525,7 @@ def test_handle_msg_releases_hold_on_error(document) -> None:
         assert document.callbacks.hold_value is None
 
 
-def test_remove_nodes_removes_every_node_matching_an_id() -> None:
+def test_remove_node_batch_removes_every_node_matching_an_id() -> None:
     """A duplicated id must not leave a stale copy behind."""
     flow = ReactFlow(
         nodes=[
@@ -1538,12 +1538,12 @@ def test_remove_nodes_removes_every_node_matching_an_id() -> None:
             {"id": "e1", "source": "n2", "target": "n1", "data": {}},
         ],
     )
-    flow.remove_nodes(["n1"])
+    flow.remove_node(["n1"])
     assert [n["id"] for n in flow.nodes] == ["n2"]
     assert flow.edges == []
 
 
-def test_remove_edges_removes_every_edge_matching_an_id() -> None:
+def test_remove_edge_batch_removes_every_edge_matching_an_id() -> None:
     flow = ReactFlow(
         nodes=[
             {"id": "n1", "position": {"x": 0, "y": 0}, "data": {}},
@@ -1555,5 +1555,43 @@ def test_remove_edges_removes_every_edge_matching_an_id() -> None:
             {"id": "e2", "source": "n1", "target": "n2", "data": {}},
         ],
     )
-    flow.remove_edges(["e1"])
+    flow.remove_edge(["e1"])
     assert [e["id"] for e in flow.edges] == ["e2"]
+
+
+def test_remove_node_accepts_varargs_and_sequences() -> None:
+    """Ids may be passed as separate arguments or as a single sequence."""
+    for remove in (
+        lambda f: f.remove_node("n1", "n2", "n3"),
+        lambda f: f.remove_node(["n1", "n2", "n3"]),
+        lambda f: f.remove_node("n1", ["n2", "n3"]),
+    ):
+        flow = _chain_flow()
+        messages = _count_sync_messages(flow, ["nodes", "edges"])
+        remove(flow)
+        assert [n["id"] for n in flow.nodes] == ["n0", "n4"]
+        assert flow.edges == []
+        assert len(messages) == 1
+
+
+def test_remove_edge_accepts_varargs_and_sequences() -> None:
+    for remove in (
+        lambda f: f.remove_edge("e0", "e1"),
+        lambda f: f.remove_edge(["e0", "e1"]),
+        lambda f: f.remove_edge("e0", ["e1"]),
+    ):
+        flow = _chain_flow()
+        messages = _count_sync_messages(flow, ["nodes", "edges"])
+        remove(flow)
+        assert [e["id"] for e in flow.edges] == ["e2", "e3"]
+        assert len(messages) == 1
+
+
+def test_remove_node_without_arguments_is_a_noop() -> None:
+    flow = _chain_flow()
+    messages = _count_sync_messages(flow, ["nodes", "edges"])
+    flow.remove_node()
+    flow.remove_edge()
+    assert len(flow.nodes) == 5
+    assert len(flow.edges) == 4
+    assert messages == []

--- a/tests/ui/test_ui.py
+++ b/tests/ui/test_ui.py
@@ -711,3 +711,91 @@ def test_connectable_handles_programmatic_edge_with_restricted_handles(page):
     assert len(flow.edges) == 1
     assert flow.edges[0]["source"] == "source"
     assert flow.edges[0]["target"] == "sink"
+
+
+_NODE_COUNT_PROBE = """
+() => {
+  const container = document.querySelector('.react-flow__nodes');
+  window.__nodeCounts = [container.childElementCount];
+  window.__probeObserver = new MutationObserver(() => {
+    window.__nodeCounts.push(container.childElementCount);
+  });
+  window.__probeObserver.observe(container, {childList: true});
+}
+"""
+
+
+def _flow_document(flow):
+    """Return the Document the served flow is rendered into."""
+    ref = next(iter(flow._models))
+    return flow._models[ref][0].document
+
+
+def _plain_flow(count=6):
+    return ReactFlow(
+        nodes=[NodeSpec(id=f"n{i}", position={"x": 160 * i, "y": 0}, label=f"N{i}").to_dict() for i in range(count)],
+        edges=[EdgeSpec(id=f"e{i}", source=f"n{i}", target=f"n{i + 1}").to_dict() for i in range(count - 1)],
+        enable_multiselect=True,
+        width=1200,
+        height=600,
+    )
+
+
+def test_remove_nodes_does_not_render_intermediate_graphs(page):
+    """The browser must never see a partially-removed graph.
+
+    Removing nodes one at a time syncs each intermediate graph, which renders
+    as the nodes disappearing progressively instead of all at once.
+    """
+    flow = _plain_flow()
+    serve_component(page, flow)
+    expect(page.locator(".react-flow__node")).to_have_count(6)
+
+    page.evaluate(_NODE_COUNT_PROBE)
+    flow.remove_nodes(["n1", "n2", "n3", "n4"])
+
+    expect(page.locator(".react-flow__node")).to_have_count(2)
+    page.wait_for_timeout(300)
+    counts = page.evaluate("window.__nodeCounts")
+    assert set(counts) <= {6, 2}, f"intermediate graphs were rendered: {counts}"
+
+
+def test_hold_does_not_render_intermediate_graphs(page):
+    """``pn.io.hold`` batches a loop of single removals into one render."""
+    flow = _plain_flow()
+    serve_component(page, flow)
+    expect(page.locator(".react-flow__node")).to_have_count(6)
+
+    page.evaluate(_NODE_COUNT_PROBE)
+    # In a served app callbacks already run with a current Document, so
+    # ``pn.io.hold()`` needs no argument; the test drives the flow from
+    # another thread and has to name the Document explicitly.
+    with pn.io.hold(_flow_document(flow)):
+        for node_id in ["n1", "n2", "n3", "n4"]:
+            flow.remove_node(node_id)
+
+    expect(page.locator(".react-flow__node")).to_have_count(2)
+    page.wait_for_timeout(300)
+    counts = page.evaluate("window.__nodeCounts")
+    assert set(counts) <= {6, 2}, f"intermediate graphs were rendered: {counts}"
+
+
+def test_multi_select_delete_does_not_render_intermediate_graphs(page):
+    """Deleting a multi-node selection from the browser renders once."""
+    flow = _plain_flow()
+    serve_component(page, flow)
+    expect(page.locator(".react-flow__node")).to_have_count(6)
+
+    _node_locator(page, "N1").click(force=True)
+    for label in ("N2", "N3", "N4"):
+        _node_locator(page, label).click(force=True, modifiers=["Shift"])
+    wait_until(lambda: len(flow.selection["nodes"]) == 4, timeout=8000)
+
+    page.evaluate(_NODE_COUNT_PROBE)
+    page.keyboard.press("Backspace")
+
+    wait_until(lambda: len(flow.nodes) == 2, timeout=8000)
+    expect(page.locator(".react-flow__node")).to_have_count(2)
+    page.wait_for_timeout(300)
+    counts = page.evaluate("window.__nodeCounts")
+    assert set(counts) <= {6, 2}, f"intermediate graphs were rendered: {counts}"

--- a/tests/ui/test_ui.py
+++ b/tests/ui/test_ui.py
@@ -714,8 +714,7 @@ def test_connectable_handles_programmatic_edge_with_restricted_handles(page):
 
 
 _NODE_COUNT_PROBE = """
-() => {
-  const container = document.querySelector('.react-flow__nodes');
+(container) => {
   window.__nodeCounts = [container.childElementCount];
   window.__probeObserver = new MutationObserver(() => {
     window.__nodeCounts.push(container.childElementCount);
@@ -723,6 +722,24 @@ _NODE_COUNT_PROBE = """
   window.__probeObserver.observe(container, {childList: true});
 }
 """
+
+
+def _record_node_counts(page):
+    """Start recording every node-container child count the browser renders.
+
+    The probe is installed on the element Playwright resolves rather than
+    looked up with ``document.querySelector``, which cannot reach into the
+    component's shadow root.
+    """
+    container = page.locator(".react-flow__nodes")
+    expect(container).to_have_count(1)
+    container.evaluate(_NODE_COUNT_PROBE)
+
+
+def _recorded_node_counts(page):
+    """Return the recorded counts once the graph has settled."""
+    page.wait_for_timeout(300)
+    return page.evaluate("window.__nodeCounts")
 
 
 def _flow_document(flow):
@@ -751,12 +768,11 @@ def test_remove_node_batch_does_not_render_intermediate_graphs(page):
     serve_component(page, flow)
     expect(page.locator(".react-flow__node")).to_have_count(6)
 
-    page.evaluate(_NODE_COUNT_PROBE)
+    _record_node_counts(page)
     flow.remove_node(["n1", "n2", "n3", "n4"])
 
     expect(page.locator(".react-flow__node")).to_have_count(2)
-    page.wait_for_timeout(300)
-    counts = page.evaluate("window.__nodeCounts")
+    counts = _recorded_node_counts(page)
     assert set(counts) <= {6, 2}, f"intermediate graphs were rendered: {counts}"
 
 
@@ -766,7 +782,7 @@ def test_hold_does_not_render_intermediate_graphs(page):
     serve_component(page, flow)
     expect(page.locator(".react-flow__node")).to_have_count(6)
 
-    page.evaluate(_NODE_COUNT_PROBE)
+    _record_node_counts(page)
     # In a served app callbacks already run with a current Document, so
     # ``pn.io.hold()`` needs no argument; the test drives the flow from
     # another thread and has to name the Document explicitly.
@@ -775,8 +791,7 @@ def test_hold_does_not_render_intermediate_graphs(page):
             flow.remove_node(node_id)
 
     expect(page.locator(".react-flow__node")).to_have_count(2)
-    page.wait_for_timeout(300)
-    counts = page.evaluate("window.__nodeCounts")
+    counts = _recorded_node_counts(page)
     assert set(counts) <= {6, 2}, f"intermediate graphs were rendered: {counts}"
 
 
@@ -791,11 +806,10 @@ def test_multi_select_delete_does_not_render_intermediate_graphs(page):
         _node_locator(page, label).click(force=True, modifiers=["Shift"])
     wait_until(lambda: len(flow.selection["nodes"]) == 4, timeout=8000)
 
-    page.evaluate(_NODE_COUNT_PROBE)
+    _record_node_counts(page)
     page.keyboard.press("Backspace")
 
     wait_until(lambda: len(flow.nodes) == 2, timeout=8000)
     expect(page.locator(".react-flow__node")).to_have_count(2)
-    page.wait_for_timeout(300)
-    counts = page.evaluate("window.__nodeCounts")
+    counts = _recorded_node_counts(page)
     assert set(counts) <= {6, 2}, f"intermediate graphs were rendered: {counts}"

--- a/tests/ui/test_ui.py
+++ b/tests/ui/test_ui.py
@@ -741,7 +741,7 @@ def _plain_flow(count=6):
     )
 
 
-def test_remove_nodes_does_not_render_intermediate_graphs(page):
+def test_remove_node_batch_does_not_render_intermediate_graphs(page):
     """The browser must never see a partially-removed graph.
 
     Removing nodes one at a time syncs each intermediate graph, which renders
@@ -752,7 +752,7 @@ def test_remove_nodes_does_not_render_intermediate_graphs(page):
     expect(page.locator(".react-flow__node")).to_have_count(6)
 
     page.evaluate(_NODE_COUNT_PROBE)
-    flow.remove_nodes(["n1", "n2", "n3", "n4"])
+    flow.remove_node(["n1", "n2", "n3", "n4"])
 
     expect(page.locator(".react-flow__node")).to_have_count(2)
     page.wait_for_timeout(300)


### PR DESCRIPTION
## Problem

A user reported that removing nodes sometimes re-renders repeatedly, with the
nodes disappearing progressively rather than all at once.

The frontend was not the cause. React Flow's `onNodesDelete` already batches
every selected id into one `node_deleted` message, and it drops the nodes from
its local state the moment the Delete key is pressed. The problem was on the
Python side: `_handle_msg` looped over the ids calling `remove_node` per node,
and each `remove_node` assigned `self.nodes` and then `self.edges` as two
separate statements.

Every assignment is its own `_param_change` call, so every assignment becomes
its own Bokeh patch and its own browser render. Deleting a three-node selection
produced six graph patches. Since the browser had already removed the nodes
locally, those patches re-added and then removed them one at a time, which is
exactly the progressive removal that was reported.

Counting `_param_change` invocations carrying `nodes`/`edges` on a five-node
chain:

| Action | Before | After |
|---|---|---|
| Frontend multi-select delete of 3 nodes | 6 | 1 |
| `remove_node("n1", "n2", "n3")` | n/a | 1 |
| Loop of 3 `remove_node` calls | 6 | 6, or 1 inside `pn.io.hold()` |
| Reassign `nodes` then `edges` | 2 | 2, or 1 inside `pn.io.hold()` |

## What this adds

`_handle_msg` now holds the document, so every parameter update triggered by a
single frontend message is combined into one patch regardless of how many
assignments the handler makes. `panel.io.document.hold` uses the `combine`
policy, which replaces earlier events for the same model and attribute, so
repeated `nodes` assignments collapse into a single dispatched event carrying
the final value. This is the general fix, and it covers handlers that were not
touched here as well as future ones.

`remove_node` and `remove_edge` take multiple ids, either as separate arguments
or as a single sequence:

```python
flow.remove_node("n1", "n2", "n3")   # also removes connected edges
flow.remove_edge(["e1", "e2"])
```

A batch assigns `nodes` and `edges` once through `param.update`, which also
removes the redundant server-side work each intermediate assignment used to
trigger: node editor rebuilds, `_views` triggers and selection recomputation.
For three nodes that is 18 watcher invocations down to 6.

Deletion events are still emitted per element, in the order the ids were given,
with each cascaded edge reported under the first node that removed it. So
`on_delete` and `on_event` hooks and `node_deleted` payloads are identical to
what sequential removal produced, which a test asserts directly.

The ids are no longer passed through a `set` in the `node_deleted` and
`edge_deleted` handlers, so event ordering follows the frontend's order instead
of being nondeterministic.

For any other batch of changes written from Python, `pn.io.hold()` does the same
job:

```python
with pn.io.hold():
    flow.nodes = new_nodes
    flow.edges = new_edges
```

That is what makes the fix general. The batch API only helps callers who use it;
the hold helps a hand-written loop or a separate `nodes`/`edges` reassignment,
which is how a user hitting this would most likely write the removal.

## Changes

- `src/panel_reactflow/base.py`: `_handle_msg` wraps the dispatch in `hold()`
  and delegates the `match` to a new `_process_msg`; `remove_node` and
  `remove_edge` accept `*ids: str | Sequence[str]` and remove in one
  `param.update`; a module-level `_flatten_ids` helper flattens the mixed
  varargs/sequence forms; `_edge_endpoints` classmethod returns an edge's
  source and target for the cascade lookup; the `node_deleted` and
  `edge_deleted` cases preserve id order.
- `tests/test_api.py`: 20 tests covering the message counts, the argument forms,
  unknown/duplicate/empty ids, event ordering and payload equivalence with
  sequential removal, `Node`/`Edge` instance detachment, and the hold behaviour
  (combining a user-written loop, `_handle_msg` installing the hold, working
  without a document, releasing the hold on error).
- `tests/ui/test_ui.py`: 3 Playwright tests that attach a `MutationObserver` to
  `.react-flow__nodes` and assert the child count only ever holds the initial or
  final value, never an intermediate one, for a batch removal, a held
  reassignment and a multi-select Delete keypress.
- `docs/how-to/define-nodes-edges.md`: the add/remove section documents passing
  several ids and the `pn.io.hold()` pattern.
- `docs/releases.md`: unreleased bug fix and enhancement entries.
